### PR TITLE
Add constraint to users table to avoid duplicate users for same site

### DIFF
--- a/migrations/033-add-contstraint-to-users-to-avoid-duplicate-user-for-single-site.js
+++ b/migrations/033-add-contstraint-to-users-to-avoid-duplicate-user-for-single-site.js
@@ -1,0 +1,12 @@
+var db = require('../src/db').sequelize;
+
+module.exports = {
+  up: async function () {
+    return db.query(`ALTER TABLE users ADD CONSTRAINT unique_users_email_per_site_id UNIQUE(siteId, email);`);
+  },
+  down: async function () {
+      return db.query(
+        `ALTER TABLE users DROP CONSTRAINT unique_users_email_per_site_id`
+      );
+  },
+};


### PR DESCRIPTION
Some users have a double entry in the users table with the same site id. Because of this users can't login and get shown the message:

> Meerdere users gevonden

By adding this constraint it should not be possible to have duplicate entries.

To check if you database has duplicate entries you can use this query:

```sql
SELECT u.email,
    u.siteId,
    u.id,
    u.externalUserId,
    u.createdAt,
    u.updatedAt,
    u.deletedAt
FROM users u
    JOIN (
        SELECT email,
            siteId
        FROM users
        GROUP BY email,
            siteId
        HAVING count(email) > 1
            AND count(siteId) > 1
    ) d ON u.email = d.email
    AND u.siteId = d.siteId;
```
