### PR TITLE
Fix database query for site.config.ideas.automaticallyUpdateStatus

### DIFF
--- a/src/cron/close_ideas.js
+++ b/src/cron/close_ideas.js
@@ -17,7 +17,7 @@ module.exports = {
     try {
 
       let sites = await db.Site.findAll({
-        where: Sequelize.where(Sequelize.fn('JSON_VALUE', Sequelize.col('config'), '$.ideas.automaticallyUpdateStatus.isActive'), true)
+        where: Sequelize.where(Sequelize.fn('JSON_VALUE', Sequelize.col('config'), Sequelize.literal('"$.ideas.automaticallyUpdateStatus.isActive"')), true)
       });
 
       for ( let site of sites ) {


### PR DESCRIPTION
Er is een crontab in de API die automatisch ideas sluit op doorlopende sites als de Stem van West (https://stemvanwest.amsterdam.nl/plannen). Dit mechanisme werkt niet (meer).

Dat blijkt te komen door een fout in een database query om te kijken wat er gedaan moet worden. Ik vermoed iets in een update van Sequelize maar dat ga ik nu niet uitzoeken. 

Deze oplossing fixed dat.