### PR TITLE
Bugfix/fix users in vote export

### DIFF
--- a/src/models/Vote.js
+++ b/src/models/Vote.js
@@ -82,7 +82,7 @@ module.exports = function( db, sequelize, DataTypes ) {
 			includeUser: {
 				include: [{
 					model      : db.User,
-					attributes : ['role', 'displayName', 'nickName', 'firstName', 'lastName', 'email', 'zipCode']
+					attributes : ['role', 'displayName', 'nickName', 'firstName', 'lastName', 'email', 'zipCode', 'postcode']
 				}]
 			},
 		}

--- a/src/routes/api/vote.js
+++ b/src/routes/api/vote.js
@@ -153,6 +153,7 @@ router.route('/')
 				vote.createdAt = entry.createdAt;
 				vote.checked =  entry.checked;
 				vote.user = entry.user;
+				if (vote.user.auth) vote.user.auth.user = req.user;
 				vote.userId = entry.userId;
 			}
       records[i] = vote


### PR DESCRIPTION
# Description

Votes export did not include user zipcode. That is now fixed.

Two things were happening: zipcode was not included in the user fields, and the cleaning up of the JSON was happening  incorrectly.
The latter because the votes export does not use the default toJSON function. That is how it should work. Because I do not have the time to extensively test, and because errors could have dire consequences, the solution for now is a workaround.

## Type of change

Bug fix

## Documentation

N/A

## Tests

Locally

## Branch

Dev, but maybe it should be a hotfix to master?
