### PR TITLE
fix: ignore theme key when sanitizing strings for extra data

### DIFF
--- a/src/lib/sequelize-authorization/lib/getExtraDataConfig.js
+++ b/src/lib/sequelize-authorization/lib/getExtraDataConfig.js
@@ -56,7 +56,7 @@ module.exports = function (dataTypeJSON,  siteConfigKey) {
             val[key] = old[key];
           }
 
-          if (typeof val[key] === 'string') {
+          if (typeof val[key] === 'string' && key !== 'theme') {
             val[key] = sanitize.safeTags(val[key]);
           }
         });


### PR DESCRIPTION
This fix ignores sanitization of the theme key in extraData. This causes a problem where theme filters don't work when a theme is used with the '&' character. This character gets escaped with the value `&amp`.

Another solution would be to sanitize the theme in the frontend widget so the api receives a sanitized theme like "Duurzaam &amp groen" instead of "Duurzaam & groen". 