### PR TITLE
fix: change query to non boolean comparison

### DIFF
--- a/src/cron/close_ideas.js
+++ b/src/cron/close_ideas.js
@@ -17,7 +17,7 @@ module.exports = {
     try {
 
       let sites = await db.Site.findAll({
-        where: Sequelize.where(Sequelize.fn('JSON_VALUE', Sequelize.col('config'), Sequelize.literal('"$.ideas.automaticallyUpdateStatus.isActive"')), true)
+        where: Sequelize.where(Sequelize.fn('JSON_VALUE', Sequelize.col('config'), Sequelize.literal('"$.ideas.automaticallyUpdateStatus.isActive"')), 'true')
       });
 
       for ( let site of sites ) {


### PR DESCRIPTION
No sites where found where the config key `ideas.automaticallyUpdateStatus.isActive` was set to true because the compared value was a boolean not a string.

Related to: https://trello.com/c/lQBlDsaO/57-automatisch-sluiten-van-ideas-werkt-niet