### PR TITLE
Add `MYSQL_CA_CERT` for MySQL SSL connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 * Remove remaining sessions
+* Allow connecting to MySQL through SSL by providing a CA certificate
 
 ## v0.40.0
 Update version number

--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ If you want to enable gitops flow in the ci pipeline of travis you need to confi
 - GITOPS_ACC_VALUES_FILE=k8s/openstad/environments/acc.values.yaml
 - GITOPS_PROD_VALUES_FILE=k8s/openstad/environments/prod.values.yaml
 
+## MySQL with SSL
+
+When you want to connect to a MySQL server using SSL, a Certificate Authority certificate is required. The contents of this CA certificate can be passed into the `MYSQL_CA_CERT` environment variable.
+
 ## Documentatie
 
 Meer informatie staat in de [docs directory](doc/index.md).
-

--- a/src/db.js
+++ b/src/db.js
@@ -23,16 +23,24 @@ if (dbConfig.mysqlSTGeoMode || process.env.MYSQL_ST_GEO_MODE === 'on') {
 	}
 }
 
+const dialectOptions = {
+	charset            : 'utf8',
+	multipleStatements : dbConfig.multipleStatements,
+	socketPath         : dbConfig.socketPath
+}
+
+if (process.env.MYSQL_CA_CERT) {
+	dialectOptions.ssl = {
+		rejectUnauthorized: true,
+		ca: [ process.env.MYSQL_CA_CERT ]
+	}
+}
 
 var sequelize = new Sequelize(dbConfig.database, dbConfig.user, dbConfig.password, {
 	dialect        : dbConfig.dialect,
 	host           : dbConfig.host,
 	port					 : dbConfig.port || 3306,
-	dialectOptions : {
-		charset            : 'utf8',
-		multipleStatements : dbConfig.multipleStatements,
-		socketPath         : dbConfig.socketPath
-	},
+	dialectOptions,
 	timeZone       : config.timeZone,
 	logging        : require('debug')('app:db:query'),
  	// logging				 : console.log,


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description

Currently it's not possible to connect to a MySQL server through SSL. This PR adds a `MYSQL_CA_CERT` environment variable which allows us to add a CA (Certificate Authority) certificate. When this certificate is provided, it is added to the MySQL connection options, and invalid SSL handshakes / certificates are rejected.


Related PRs have been made in the auth, image & kubernetes repositories: 

https://github.com/openstad/openstad-oauth2-server/pull/113
https://github.com/openstad/openstad-image-server/pull/35
https://github.com/openstad/openstad-kubernetes/pull/78

## Issue reference



## Type of change

New feature through an environment variable. Keeps backwards compatibility.

## Documentation

See README.md

## Tests

Locally

## Branch



