### PR TITLE
Added no sentiment option for the database model and fetching of no s…

### DIFF
--- a/migrations/034-add-enum-to-sentimen-in-arguments.js
+++ b/migrations/034-add-enum-to-sentimen-in-arguments.js
@@ -1,0 +1,16 @@
+let db = require('../src/db').sequelize;
+
+module.exports = {
+  up: function() {
+
+    try {
+      return db.query(`
+        ALTER TABLE arguments MODIFY COLUMN sentiment
+        ENUM('against', 'for', 'no sentiment');
+			`);
+    } catch(e) {
+      return true;
+    }
+
+  }
+}

--- a/src/models/Argument.js
+++ b/src/models/Argument.js
@@ -39,7 +39,7 @@ module.exports = function( db, sequelize, DataTypes ) {
 		},
 
 		sentiment: {
-			type         : DataTypes.ENUM('against', 'for'),
+			type         : DataTypes.ENUM('against', 'for', 'no sentiment'),
 			defaultValue : 'for',
 			allowNull    : false
 		},

--- a/src/routes/api/argument.js
+++ b/src/routes/api/argument.js
@@ -50,7 +50,7 @@ router
     let sentiment = req.query.sentiment;
     let where = { id: argumentId };
 
-    if (sentiment && (sentiment == 'against' || sentiment == 'for')) {
+    if (sentiment && (sentiment == 'against' || sentiment == 'for' || sentiment == 'no sentiment')) {
       where.sentiment = sentiment;
     }
 
@@ -83,7 +83,7 @@ router.route('/')
       where.ideaId = ideaId;
     }
     let sentiment = req.query.sentiment;
-    if (sentiment && (sentiment == 'against' || sentiment == 'for')) {
+    if (sentiment && (sentiment == 'against' || sentiment == 'for' || sentiment == 'no sentiment')) {
       where.sentiment = sentiment;
     }
 


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description
Made it possible for arguments with 'no sentiment' to be added to the databases.
Needs https://github.com/openstad/openstad-frontend/pull/357 to fully work, given that the frontend will need to provide the 'no sentiment' value

## Issue reference

Fixes # (issue)
Belongs to bug https://trello.com/c/URra6zQt

## Type of change
bugfix (wrong branchname, by accident)

## Tests
- Login as admin on a site of your choosing.
- Go to 'plannen'
- Create a plan to use if no plans are available
- go to the ' edit arguments' section and change one of the boxes to use to the 'no sentiment' option.

## Branch
devel

