### PR TITLE
Feat/create docker container on push

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -13,6 +13,8 @@ jobs:
     name: Build Docker image and push to repositories
     # run only when code is compiling and tests are passing
     runs-on: ubuntu-latest
+    env:
+      IMAGE: ${{ secrets.DOCKER_IMAGE || 'openstad/api' }}
     # steps to perform in job
     steps:
       - name: Checkout code
@@ -22,7 +24,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: openstad/api
+          images: ${{ env.IMAGE }}
           tags: |
             # branch event
             type=ref,event=branch,suffix=-{{sha}}
@@ -35,7 +37,6 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -57,7 +58,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.repos.createCommitComment({
-              issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -7,9 +7,6 @@ on:
       - '**'
     tags:
       - "v*"
-  pull_request:
-    branches:
-      - 'master'
 jobs:
   # define job to build and publish docker image
   build-and-push-docker-image:
@@ -54,22 +51,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
-      # Comment build info in PR
-      - uses: actions/github-script@0.9.0
-        if: github.event_name == 'pull_request'
-        env:
-          STDOUT: "```${{ steps.docker_build.outputs.metadata }}```"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: process.env.STDOUT
-            })
-
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.metadata  }}
-
+        run: echo "${{ steps.docker_build.outputs.metadata }}"
        

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -52,7 +52,7 @@ jobs:
       # Comment build info in commit
       - uses: actions/github-script@0.9.0
         env:
-          STDOUT: "Published new image: `${{ steps.docker_build.outputs.metadata.image.name }}`"
+          STDOUT: "Published new image: `${{ fromJson(steps.docker_build.outputs.metadata).image.name }}`"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -7,9 +7,6 @@ on:
       - '**'
     tags:
       - "v*"
-  pull_request:
-    branches:
-      - 'master'
 jobs:
   # define job to build and publish docker image
   build-and-push-docker-image:
@@ -52,9 +49,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
-      # Comment build info in PR
+      # Comment build info in commit
       - uses: actions/github-script@0.9.0
-        if: github.event_name == 'pull_request'
         env:
           STDOUT: "Published new image: `${{ steps.docker_build.outputs.metadata.image.name }}`"
         with:

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -7,6 +7,9 @@ on:
       - '**'
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - 'master'
 jobs:
   # define job to build and publish docker image
   build-and-push-docker-image:
@@ -28,8 +31,6 @@ jobs:
             type=ref,event=branch,suffix=-{{sha}}
             # tag event
             type=ref,event=tag
-            # pull request event
-            type=ref,event=pr
 
       # setup Docker buld action
       - name: Set up Docker Buildx
@@ -50,6 +51,22 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+
+      # Comment build info in PR
+      - uses: actions/github-script@0.9.0
+        if: github.event_name == 'pull_request'
+        env:
+          STDOUT: "Published new image: `${{ steps.docker_build.outputs.metadata.image.name }}`"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: process.env.STDOUT
+            })
 
       - name: Image digest
         run: echo "${{ steps.docker_build.outputs.metadata }}"

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -52,7 +52,7 @@ jobs:
       # Comment build info in commit
       - uses: actions/github-script@0.9.0
         env:
-          STDOUT: "Published new image: `${{ fromJson(steps.docker_build.outputs.metadata).image.name }}`"
+          STDOUT: "Published new image: `${{ fromJson(steps.docker_build.outputs.metadata)['image.name'] }}`"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -3,8 +3,13 @@
 name: Build and Publish Version Tags
 on:
   push:
+    branches:
+      - '**'
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - 'master'
 jobs:
   # define job to build and publish docker image
   build-and-push-docker-image:
@@ -16,12 +21,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-   #   - name: tag number
-#        run : echo ${{ github.event.release.tag_name }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: openstad/api
+          tags: |
+            # branch event
+            type=ref,event=branch,suffix=-{{sha}}
+            # tag event
+            type=ref,event=tag
+            # pull request event
+            type=ref,event=pr
 
       # setup Docker buld action
       - name: Set up Docker Buildx
@@ -29,6 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -38,12 +50,12 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          push: true # ${{ github.event_name != 'pull_request' }}
           # Note: tags has to be all lower-case
-          tags: |
-            openstad/api:${{ steps.get_version.outputs.VERSION }}
+          tags: ${{ steps.meta.outputs.tags }}
           # build on feature branches, push only on main branch
-          ##push: ${{ github.ref == 'refs/heads/main' }}
+          # push: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 

--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -47,16 +47,29 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build image and push to Docker Hub and GitHub Container Registry
+        id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true # ${{ github.event_name != 'pull_request' }}
-          # Note: tags has to be all lower-case
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
-          # build on feature branches, push only on main branch
-          # push: ${{ github.ref == 'refs/heads/main' }}
+
+      # Comment build info in PR
+      - uses: actions/github-script@0.9.0
+        if: github.event_name == 'pull_request'
+        env:
+          STDOUT: "```${{ steps.docker_build.outputs.metadata }}```"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: process.env.STDOUT
+            })
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{ steps.docker_build.outputs.metadata  }}
 
        


### PR DESCRIPTION
# Description

This PR adds new docker builds on push. Every push gets build by Github CI and tags the build with the branch name and commit sha. For example: `feat-create-docker-container-on-push-07a8c10`. This allows you to quickly test new features. On successful build this also creates a comment with the released image.

## Type of change

Feature

## Documentation

None

## Tests

Tested via GitHub workflow.

## Branch

`master`

