### PR TITLE
Add locks

### DIFF
--- a/migrations/037-add-locks.js
+++ b/migrations/037-add-locks.js
@@ -1,0 +1,30 @@
+let db = require('../src/db').sequelize;
+
+module.exports = {
+  up: function() {
+
+    try {
+      return db.query(`
+
+        CREATE TABLE locks (
+          id int(11) NOT NULL,
+          type varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+          createdAt datetime NOT NULL,
+          updatedAt datetime NOT NULL,
+          deletedAt datetime DEFAULT NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+        
+        ALTER TABLE locks
+          ADD PRIMARY KEY (id);
+        
+        ALTER TABLE locks
+          MODIFY id int(11) NOT NULL AUTO_INCREMENT;
+        COMMIT;
+
+			`);
+    } catch(e) {
+      return true;
+    }
+
+  }
+}

--- a/src/models/Lock.js
+++ b/src/models/Lock.js
@@ -1,0 +1,21 @@
+module.exports = function( db, sequelize, DataTypes ) {
+  let Lock = sequelize.define('lock', {
+
+    type: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+
+  });
+
+  Lock.auth = Lock.prototype.auth = {
+    listableBy: 'admin',
+    viewableBy: 'admin',
+    createableBy: 'admin',
+    updateableBy: 'admin',
+    deleteableBy: 'admin',
+  }
+
+
+  return Lock;
+}


### PR DESCRIPTION
# Description

The API has several cron scripts running. When, for example in a k8s setting, multiple instances of the API are running, each will run these cron scripts, possibly at the same time.

This update provides a locking mechanism to deal with that.

An example test script will be in the next comment.

## Type of change

Feature
