### PR TITLE
Feature/anonymize site users

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -66,6 +66,10 @@ let defaultConfig = {
 		}
 	},
 
+  "anonymize": {
+    "anonimizeUsersXDaysAfterNotification": 60,
+  },
+  
 	"authorization": {
 
 		"jwt-secret": "xxxxx",
@@ -303,6 +307,7 @@ defaultConfig.mail.transport.smtp.requireSSL = process.env.API_MAIL_TRANSPORT_SM
 defaultConfig.mail.transport.smtp.auth.user = process.env.API_MAIL_TRANSPORT_SMTP_AUTH_USER || defaultConfig.mail.transport.smtp.auth.user;
 defaultConfig.mail.transport.smtp.auth.pass = process.env.API_MAIL_TRANSPORT_SMTP_AUTH_PASS || defaultConfig.mail.transport.smtp.auth.pass;
 defaultConfig.notifications.admin.emailAddress = process.env.API_NOTIFICATIONS_ADMIN_EMAILADDRESS || defaultConfig.notifications.admin.emailAddress;
+defaultConfig.anonymize.anonimizeUsersXDaysAfterNotification = process.env.ANONIMIZE_USERS_X_DAYS_AFTER_NOTIFICATION || defaultConfig.anonymize.anonimizeUsersXDaysAfterNotification;
 defaultConfig.authorization['jwt-secret'] = process.env.API_AUTHORIZATION_JWTSECRET || defaultConfig.authorization['jwt-secret'];
 defaultConfig.authorization['auth-server-url'] = process.env.AUTH_API_URL || defaultConfig.authorization['auth-server-url'];
 defaultConfig.authorization["auth-client-id"] = process.env.AUTH_FIRST_CLIENT_ID || defaultConfig.authorization["auth-client-id"];

--- a/config/default.js
+++ b/config/default.js
@@ -63,7 +63,12 @@ let defaultConfig = {
 			// Special high-frequency email notifications for site administrators.
 			// Should probably not be a personal email account.
 			"emailAddress": null
-		}
+		},
+    "sendEndDateNotifications": {
+      "XDaysBefore": 2,
+      "subject": "project bijna afgelopen",
+      "template": "Het project op {{URL}} nadert de einddatum. Vergeet niet om het vinkje PorjectHasEnded te zetten."
+    },
 	},
 
   "anonymize": {

--- a/config/default.js
+++ b/config/default.js
@@ -65,16 +65,12 @@ let defaultConfig = {
 			"emailAddress": null
 		},
     "sendEndDateNotifications": {
-      "XDaysBefore": 2,
+      "XDaysBefore": 7,
       "subject": "project bijna afgelopen",
       "template": "Het project op {{URL}} nadert de einddatum. Vergeet niet om het vinkje PorjectHasEnded te zetten."
     },
 	},
 
-  "anonymize": {
-    "anonimizeUsersXDaysAfterNotification": 60,
-  },
-  
 	"authorization": {
 
 		"jwt-secret": "xxxxx",
@@ -95,9 +91,9 @@ let defaultConfig = {
 		// When an idea is closed, this threshold must be met or the idea
 		// will be automatically denied.
 		"minimumYesVotes": 100,
-		// Threshold in days after which votes are anonimized (IP removed).
-		// Votes that are earmarked as fraudulous are never anonimized.
-		"anonimizeThreshold": 180,
+		// Threshold in days after which votes are anonymized (IP removed).
+		// Votes that are earmarked as fraudulous are never anonymized.
+		"anonymizeThreshold": 180,
 		// Minimum number of votes before it influences the date sorting of
 		// and idea's arguments.
 
@@ -312,7 +308,6 @@ defaultConfig.mail.transport.smtp.requireSSL = process.env.API_MAIL_TRANSPORT_SM
 defaultConfig.mail.transport.smtp.auth.user = process.env.API_MAIL_TRANSPORT_SMTP_AUTH_USER || defaultConfig.mail.transport.smtp.auth.user;
 defaultConfig.mail.transport.smtp.auth.pass = process.env.API_MAIL_TRANSPORT_SMTP_AUTH_PASS || defaultConfig.mail.transport.smtp.auth.pass;
 defaultConfig.notifications.admin.emailAddress = process.env.API_NOTIFICATIONS_ADMIN_EMAILADDRESS || defaultConfig.notifications.admin.emailAddress;
-defaultConfig.anonymize.anonimizeUsersXDaysAfterNotification = process.env.ANONIMIZE_USERS_X_DAYS_AFTER_NOTIFICATION || defaultConfig.anonymize.anonimizeUsersXDaysAfterNotification;
 defaultConfig.authorization['jwt-secret'] = process.env.API_AUTHORIZATION_JWTSECRET || defaultConfig.authorization['jwt-secret'];
 defaultConfig.authorization['auth-server-url'] = process.env.AUTH_API_URL || defaultConfig.authorization['auth-server-url'];
 defaultConfig.authorization["auth-client-id"] = process.env.AUTH_FIRST_CLIENT_ID || defaultConfig.authorization["auth-client-id"];

--- a/migrations/035-add-last-login-to-user.js
+++ b/migrations/035-add-last-login-to-user.js
@@ -1,0 +1,15 @@
+let db = require('../src/db').sequelize;
+
+module.exports = {
+  up: function() {
+
+    try {
+      return db.query(`
+        ALTER TABLE users ADD lastLogin DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER signedUpForNewsletter; 
+			`);
+    } catch(e) {
+      return true;
+    }
+
+  }
+}

--- a/migrations/038-add-is-notified-about-anonymization-to-user.js
+++ b/migrations/038-add-is-notified-about-anonymization-to-user.js
@@ -1,0 +1,15 @@
+let db = require('../src/db').sequelize;
+
+module.exports = {
+  up: function() {
+
+    try {
+      return db.query(`
+        ALTER TABLE users ADD isNotifiedAboutAnonymization DATETIME NULL DEFAULT NULL AFTER lastLogin; 
+			`);
+    } catch(e) {
+      return true;
+    }
+
+  }
+}

--- a/migrations/039-drop-locks-deletedAt.js
+++ b/migrations/039-drop-locks-deletedAt.js
@@ -1,0 +1,15 @@
+let db = require('../src/db').sequelize;
+
+module.exports = {
+  up: function() {
+
+    try {
+      return db.query(`
+        ALTER TABLE locks DROP deletedAt; 
+			`);
+    } catch(e) {
+      return true;
+    }
+
+  }
+}

--- a/src/cron/anon_votes.js
+++ b/src/cron/anon_votes.js
@@ -12,15 +12,15 @@ module.exports = {
 	runOnInit: true,
 	onTick: function() {
 		Promise.all([
-			db.Vote.anonimizeOldVotes(),
-			db.ArgumentVote.anonimizeOldVotes()
+			db.Vote.anonymizeOldVotes(),
+			db.ArgumentVote.anonymizeOldVotes()
 		])
 		.then(function([ voteResult, argVoteResult ]) {
 			if( voteResult && voteResult.affectedRows ) {
-				log(`anonimized votes: ${voteResult.affectedRows}`);
+				log(`anonymized votes: ${voteResult.affectedRows}`);
 			}
 			if( argVoteResult && argVoteResult.affectedRows ) {
-				log(`anonimized argument votes: ${argVoteResult.affectedRows}`);
+				log(`anonymized argument votes: ${argVoteResult.affectedRows}`);
 			}
 		});
 	}

--- a/src/cron/anonymize_inactive_users.js
+++ b/src/cron/anonymize_inactive_users.js
@@ -11,11 +11,11 @@ const UseLock = require('../lib/use-lock');
 // 
 // Runs every day
 module.exports = {
-	// cronTime: '*/10 * * * * *',
-	// runOnInit: true,
-	cronTime: '0 30 4 * * *',
-	runOnInit: false,
-	onTick: UseLock.createLockedExecutable({
+  // cronTime: '*/10 * * * * *',
+  // runOnInit: true,
+  cronTime: '0 30 4 * * *',
+  runOnInit: false,
+  onTick: UseLock.createLockedExecutable({
     name: 'anonymize-inactive-users',
     task: async (next) => {
 
@@ -27,11 +27,11 @@ module.exports = {
         let sites = await db.Site.findAll();
         for (let i=0; i < sites.length; i++) {
           let site = sites[i];
+
+          // find users that have not logged in for a while
           let anonimizeUsersAfterXDaysOfInactivity = site.config.anonymize.anonimizeUsersAfterXDaysOfInactivity;
           let targetDate = new Date();
           targetDate.setDate(targetDate.getDate() - anonimizeUsersAfterXDaysOfInactivity);
-
-          // find users that have not logged in for a while
           let users = await db.User.findAll({
             where: {
               siteId: site.id,

--- a/src/cron/anonymize_inactive_users.js
+++ b/src/cron/anonymize_inactive_users.js
@@ -11,10 +11,10 @@ const UseLock = require('../lib/use-lock');
 // 
 // Runs every day
 module.exports = {
-	cronTime: '*/10 * * * * *',
-	runOnInit: true,
-	// cronTime: '0 30 4 * * *',
-	// runOnInit: false,
+	// cronTime: '*/10 * * * * *',
+	// runOnInit: true,
+	cronTime: '0 30 4 * * *',
+	runOnInit: false,
 	onTick: UseLock.createLockedExecutable({
     name: 'anonymize-inactive-users',
     task: async (next) => {

--- a/src/cron/anonymize_inactive_users.js
+++ b/src/cron/anonymize_inactive_users.js
@@ -1,0 +1,80 @@
+const { Sequelize, Op } = require('sequelize');
+const log = require('debug')('app:cron');
+const config = require('config');
+const mail = require('../lib/mail');
+const db = require('../db');
+const UseLock = require('../lib/use-lock');
+
+// Purpose
+// -------
+// Send emails to users that have not logged in for a long time and anonymize those users if they do not respond
+// 
+// Runs every day
+module.exports = {
+	cronTime: '*/10 * * * * *',
+	runOnInit: true,
+	// cronTime: '0 30 4 * * *',
+	// runOnInit: false,
+	onTick: UseLock.createLockedExecutable({
+    name: 'anonymize-inactive-users',
+    task: async (next) => {
+
+      let anonimizeUsersXDaysAfterNotification = config.anonymize.anonimizeUsersXDaysAfterNotification;
+
+      try {
+
+        // for each site
+        let sites = await db.Site.findAll();
+        for (let i=0; i < sites.length; i++) {
+          let site = sites[i];
+          let anonimizeUsersAfterXDaysOfInactivity = site.config.anonymize.anonimizeUsersAfterXDaysOfInactivity;
+          let targetDate = new Date();
+          targetDate.setDate(targetDate.getDate() - anonimizeUsersAfterXDaysOfInactivity);
+
+          // find users that have not logged in for a while
+          let users = await db.User.findAll({
+            where: {
+              siteId: site.id,
+              role: 'member',
+              lastLogin: {
+                [Sequelize.Op.lte]: targetDate,
+              }
+            }
+          })
+          if (users.length > 0) {
+
+            // for each user
+            for (let i = 0; i < users.length; i++) {
+              let user = users[i];
+
+              if (user.isNotifiedAboutAnonymization) {
+                let daysSinceNotification = parseInt( (Date.now() - new Date(user.isNotifiedAboutAnonymization).getTime()) / ( 24 * 60 * 60 * 1000 ) );
+                if (daysSinceNotification > anonimizeUsersXDaysAfterNotification) {
+                  console.log('CRON anonymize-inactive-users: anonymize user', user.email, user.lastLogin);
+                  // anonymize user
+                  user.doAnonymize();
+                }
+              } else {
+                // send notification
+                console.log('CRON anonymize-inactive-users: send warning email to user', user.email, user.lastLogin);
+                mail.sendInactiveWarningEmail(site, user);
+                user.update({ isNotifiedAboutAnonymization: new Date() });
+              }
+
+            }
+          }
+        }
+
+        return next();
+
+      } catch (err) {
+        console.log('error in anonymize-inactive-users cron');
+        next(err); // let the locked function handle this
+      }
+      
+    }
+  })
+
+};
+
+

--- a/src/cron/send_enddate_notifications.js
+++ b/src/cron/send_enddate_notifications.js
@@ -11,11 +11,11 @@ const UseLock = require('../lib/use-lock');
 // 
 // Runs every day
 module.exports = {
-	// cronTime: '*/10 * * * * *',
-	// runOnInit: true,
-	cronTime: '0 30 4 * * *',
-	runOnInit: false,
-	onTick: UseLock.createLockedExecutable({
+  // cronTime: '*/10 * * * * *',
+  // runOnInit: true,
+  cronTime: '0 30 4 * * *',
+  runOnInit: false,
+  onTick: UseLock.createLockedExecutable({
     name: 'send-enddate-notifications',
     task: async (next) => {
 
@@ -26,7 +26,7 @@ module.exports = {
         // for each site
         let targetDate = new Date();
         targetDate.setDate(targetDate.getDate() - endDateConfig.XDaysBefore);
-				let sites = await db.Site.findAll({
+        let sites = await db.Site.findAll({
           where: {
             [Sequelize.Op.and]: [
               {
@@ -59,36 +59,35 @@ module.exports = {
                     projectHasEnded: false,
                   }
                 }
-//            }, {
-//              config: {
-//                project: {
-//                  endDateNotificationSent: false
-//                }
-//              }
+                //            }, {
+                //              config: {
+                //                project: {
+                //                  endDateNotificationSent: false
+                //                }
+                //              }
               }
             ]
           }
         });
-				for (let i=0; i < sites.length; i++) {
-					let site = sites[i];
+        for (let i=0; i < sites.length; i++) {
+          let site = sites[i];
 
           if (!site.config.project.endDateNotificationSent) { // todo: the where clause above does not work for reasons I do not have time for now
 
+            // send notification
             let data = {
               from: site.config.notifications.fromAddress,
               to: site.config.notifications.projectmanagerAddress,
               subject:  endDateConfig.subject,
               template:  endDateConfig.template,
             };
-
-					  // send notification
-					  console.log('CRON send-enddate-notifications: send email to projectmanager');
-					  Notifications.sendMessage({ site, data });
-					  site.update({ config: { project: { endDateNotificationSent: true } } });
+            console.log('CRON send-enddate-notifications: send email to projectmanager');
+            Notifications.sendMessage({ site, data });
+            site.update({ config: { project: { endDateNotificationSent: true } } });
 
           }
         }
-				
+        
         return next();
 
       } catch (err) {

--- a/src/cron/send_enddate_notifications.js
+++ b/src/cron/send_enddate_notifications.js
@@ -11,10 +11,10 @@ const UseLock = require('../lib/use-lock');
 // 
 // Runs every day
 module.exports = {
-	cronTime: '*/10 * * * * *',
-	runOnInit: true,
-	// cronTime: '0 30 4 * * *',
-	// runOnInit: false,
+	// cronTime: '*/10 * * * * *',
+	// runOnInit: true,
+	cronTime: '0 30 4 * * *',
+	runOnInit: false,
 	onTick: UseLock.createLockedExecutable({
     name: 'send-enddate-notifications',
     task: async (next) => {

--- a/src/cron/send_enddate_notifications.js
+++ b/src/cron/send_enddate_notifications.js
@@ -53,16 +53,18 @@ module.exports = {
                     }
                   }
                 }
-//              }, {
-//                config: {
-//                  project: {
-//                    endDateNotificationSent: false
-//                  }
-//                }
               }, {
                 config: {
-                  projectHasEnded: false,
+                  project: {
+                    projectHasEnded: false,
+                  }
                 }
+//            }, {
+//              config: {
+//                project: {
+//                  endDateNotificationSent: false
+//                }
+//              }
               }
             ]
           }

--- a/src/cron/send_enddate_notifications.js
+++ b/src/cron/send_enddate_notifications.js
@@ -1,0 +1,101 @@
+const { Sequelize, Op } = require('sequelize');
+const log = require('debug')('app:cron');
+const config = require('config');
+const Notifications = require('../notifications');
+const db = require('../db');
+const UseLock = require('../lib/use-lock');
+
+// Purpose
+// -------
+// Send emails to projectmanagers just before the enddate of their project is reached
+// 
+// Runs every day
+module.exports = {
+	cronTime: '*/10 * * * * *',
+	runOnInit: true,
+	// cronTime: '0 30 4 * * *',
+	// runOnInit: false,
+	onTick: UseLock.createLockedExecutable({
+    name: 'send-enddate-notifications',
+    task: async (next) => {
+
+      let endDateConfig = config.notifications.sendEndDateNotifications;
+
+      try {
+
+        // for each site
+        let targetDate = new Date();
+        targetDate.setDate(targetDate.getDate() - endDateConfig.XDaysBefore);
+				let sites = await db.Site.findAll({
+          where: {
+            [Sequelize.Op.and]: [
+              {
+                config: {
+                  project: {
+                    endDate: {
+                      [Sequelize.Op.not]: null
+                    }
+                  }
+                }
+              }, {
+                config: {
+                  project: {
+                    endDate: {
+                      [Sequelize.Op.lte]: new Date(),
+                    }
+                  }
+                }
+              }, {
+                config: {
+                  project: {
+                    endDate: {
+                      [Sequelize.Op.gte]: targetDate,
+                    }
+                  }
+                }
+//              }, {
+//                config: {
+//                  project: {
+//                    endDateNotificationSent: false
+//                  }
+//                }
+              }, {
+                config: {
+                  projectHasEnded: false,
+                }
+              }
+            ]
+          }
+        });
+				for (let i=0; i < sites.length; i++) {
+					let site = sites[i];
+
+          if (!site.config.project.endDateNotificationSent) { // todo: the where clause above does not work for reasons I do not have time for now
+
+            let data = {
+              from: site.config.notifications.fromAddress,
+              to: site.config.notifications.projectmanagerAddress,
+              subject:  endDateConfig.subject,
+              template:  endDateConfig.template,
+            };
+
+					  // send notification
+					  console.log('CRON send-enddate-notifications: send email to projectmanager');
+					  Notifications.sendMessage({ site, data });
+					  site.update({ config: { project: { endDateNotificationSent: true } } });
+
+          }
+        }
+				
+        return next();
+
+      } catch (err) {
+        console.log('error in send-enddate-notifications cron');
+        next(err); // let the locked function handle this
+      }
+      
+    }
+  })
+
+};
+

--- a/src/cron/send_idea_notifications.js
+++ b/src/cron/send_idea_notifications.js
@@ -8,8 +8,8 @@ var notifications = require('../notifications');
 // Runs every 5 minutes on the 15th second, because the close_ideas
 // cron already runs on the 0th second.
 module.exports = {
-	cronTime: '*/5 * * * * *',
-	//cronTime: '20 */5 * * * *',
+	//cronTime: '*/5 * * * * *',
+	cronTime: '20 */5 * * * *',
 	runOnInit: false,
 	onTick: function() {
 		notifications.processQueue('idea');

--- a/src/cron/send_idea_notifications.js
+++ b/src/cron/send_idea_notifications.js
@@ -8,8 +8,8 @@ var notifications = require('../notifications');
 // Runs every 5 minutes on the 15th second, because the close_ideas
 // cron already runs on the 0th second.
 module.exports = {
-	//cronTime: '*/5 * * * * *',
-	cronTime: '20 */5 * * * *',
+	cronTime: '*/5 * * * * *',
+	//cronTime: '20 */5 * * * *',
 	runOnInit: false,
 	onTick: function() {
 		notifications.processQueue('idea');

--- a/src/cron/send_site_issues_notifications.js
+++ b/src/cron/send_site_issues_notifications.js
@@ -12,11 +12,11 @@ const sitesWithIssues = require('../services/sites-with-issues');
 // 
 // Runs every day
 module.exports = {
-	// cronTime: '*/10 * * * * *',
-	// runOnInit: true,
-	cronTime: '0 15 4 * * *',
-	runOnInit: false,
-	onTick: UseLock.createLockedExecutable({
+  // cronTime: '*/10 * * * * *',
+  // runOnInit: true,
+  cronTime: '0 15 4 * * *',
+  runOnInit: false,
+  onTick: UseLock.createLockedExecutable({
     name: 'send-site-issues-notifications',
     task: async (next) => {
 
@@ -29,7 +29,7 @@ module.exports = {
         let shouldHaveEndedButAreNot = result.rows;
 
         // for each site
-  			for (let i=0; i < shouldHaveEndedButAreNot.length; i++) {
+        for (let i=0; i < shouldHaveEndedButAreNot.length; i++) {
           let site = shouldHaveEndedButAreNot[i];
           if (!notoficationsToBeSent[ site.id ]) notoficationsToBeSent[ site.id ] = { site, messages: [] };
           notoficationsToBeSent[ site.id ].messages.push(`Site ${ site.title } (${ site.domain }) has an endDate in the past but projectHasEnded is not set.`);
@@ -40,7 +40,7 @@ module.exports = {
         let endedButNotAnonimized = result.rows;
 
         // for each site
-  			for (let i=0; i < endedButNotAnonimized.length; i++) {
+        for (let i=0; i < endedButNotAnonimized.length; i++) {
           let site = endedButNotAnonimized[i];
           if (!notoficationsToBeSent[ site.id ]) notoficationsToBeSent[ site.id ] = { site, messages: [] };
           notoficationsToBeSent[ site.id ].messages.push(`Project ${ site.title } (${ site.domain }) has ended but is not yet anonimized.`);
@@ -57,7 +57,7 @@ module.exports = {
           };
           Notifications.sendMessage({ site: target.site, data });
         });
-				
+        
         return next();
 
       } catch (err) {

--- a/src/cron/send_site_issues_notifications.js
+++ b/src/cron/send_site_issues_notifications.js
@@ -22,7 +22,7 @@ module.exports = {
 
       try {
 
-        let notoficationsToBeSent = {};
+        let notificationsToBeSent = {};
 
         // sites that should be ended but are not
         let result = await sitesWithIssues.shouldHaveEndedButAreNot({});
@@ -31,24 +31,24 @@ module.exports = {
         // for each site
         for (let i=0; i < shouldHaveEndedButAreNot.length; i++) {
           let site = shouldHaveEndedButAreNot[i];
-          if (!notoficationsToBeSent[ site.id ]) notoficationsToBeSent[ site.id ] = { site, messages: [] };
-          notoficationsToBeSent[ site.id ].messages.push(`Site ${ site.title } (${ site.domain }) has an endDate in the past but projectHasEnded is not set.`);
+          if (!notificationsToBeSent[ site.id ]) notificationsToBeSent[ site.id ] = { site, messages: [] };
+          notificationsToBeSent[ site.id ].messages.push(`Site ${ site.title } (${ site.domain }) has an endDate in the past but projectHasEnded is not set.`);
         }
 
-        // sites that have ended but are not anonimized
-        result = await sitesWithIssues.endedButNotAnonimized({})
-        let endedButNotAnonimized = result.rows;
+        // sites that have ended but are not anonymized
+        result = await sitesWithIssues.endedButNotAnonymized({})
+        let endedButNotAnonymized = result.rows;
 
         // for each site
-        for (let i=0; i < endedButNotAnonimized.length; i++) {
-          let site = endedButNotAnonimized[i];
-          if (!notoficationsToBeSent[ site.id ]) notoficationsToBeSent[ site.id ] = { site, messages: [] };
-          notoficationsToBeSent[ site.id ].messages.push(`Project ${ site.title } (${ site.domain }) has ended but is not yet anonimized.`);
+        for (let i=0; i < endedButNotAnonymized.length; i++) {
+          let site = endedButNotAnonymized[i];
+          if (!notificationsToBeSent[ site.id ]) notificationsToBeSent[ site.id ] = { site, messages: [] };
+          notificationsToBeSent[ site.id ].messages.push(`Project ${ site.title } (${ site.domain }) has ended but is not yet anonymized.`);
         }
 
         // send notifications
-        Object.keys(notoficationsToBeSent).forEach(id => {
-          let target = notoficationsToBeSent[ id ];
+        Object.keys(notificationsToBeSent).forEach(id => {
+          let target = notificationsToBeSent[ id ];
           let data = {
             from: target.site.config.notifications.fromAddress,
             to: target.site.config.notifications.siteadminAddress,

--- a/src/cron/send_site_issues_notifications.js
+++ b/src/cron/send_site_issues_notifications.js
@@ -1,0 +1,72 @@
+const { Sequelize, Op } = require('sequelize');
+const log = require('debug')('app:cron');
+const config = require('config');
+const Notifications = require('../notifications');
+const db = require('../db');
+const UseLock = require('../lib/use-lock');
+const sitesWithIssues = require('../services/sites-with-issues');
+
+// Purpose
+// -------
+// Send emails to projectmanagers just before the enddate of their project is reached
+// 
+// Runs every day
+module.exports = {
+	// cronTime: '*/10 * * * * *',
+	// runOnInit: true,
+	cronTime: '0 15 4 * * *',
+	runOnInit: false,
+	onTick: UseLock.createLockedExecutable({
+    name: 'send-site-issues-notifications',
+    task: async (next) => {
+
+      try {
+
+        let notoficationsToBeSent = {};
+
+        // sites that should be ended but are not
+        let result = await sitesWithIssues.shouldHaveEndedButAreNot({});
+        let shouldHaveEndedButAreNot = result.rows;
+
+        // for each site
+  			for (let i=0; i < shouldHaveEndedButAreNot.length; i++) {
+          let site = shouldHaveEndedButAreNot[i];
+          if (!notoficationsToBeSent[ site.id ]) notoficationsToBeSent[ site.id ] = { site, messages: [] };
+          notoficationsToBeSent[ site.id ].messages.push(`Site ${ site.title } (${ site.domain }) has an endDate in the past but projectHasEnded is not set.`);
+        }
+
+        // sites that have ended but are not anonimized
+        result = await sitesWithIssues.endedButNotAnonimized({})
+        let endedButNotAnonimized = result.rows;
+
+        // for each site
+  			for (let i=0; i < endedButNotAnonimized.length; i++) {
+          let site = endedButNotAnonimized[i];
+          if (!notoficationsToBeSent[ site.id ]) notoficationsToBeSent[ site.id ] = { site, messages: [] };
+          notoficationsToBeSent[ site.id ].messages.push(`Project ${ site.title } (${ site.domain }) has ended but is not yet anonimized.`);
+        }
+
+        // send notifications
+        Object.keys(notoficationsToBeSent).forEach(id => {
+          let target = notoficationsToBeSent[ id ];
+          let data = {
+            from: target.site.config.notifications.fromAddress,
+            to: target.site.config.notifications.siteadminAddress,
+            subject: 'Sites with issues',
+            template: target.messages.join('\r\n'),
+          };
+          Notifications.sendMessage({ site: target.site, data });
+        });
+				
+        return next();
+
+      } catch (err) {
+        console.log('error in send-site-issues-notifications cron');
+        next(err); // let the locked function handle this
+      }
+      
+    }
+  })
+
+};
+

--- a/src/lib/mail.js
+++ b/src/lib/mail.js
@@ -229,6 +229,7 @@ function sendInactiveWarningEmail(site, user) {
   if (!fromAddress) return console.error('Email error: fromAddress not provided');
   if (fromAddress.match(/^.+<(.+)>$/, '$1')) fromAddress = fromAddress.replace(/^.+<(.+)>$/, '$1');
   const logo =  siteConfig.getLogo();
+  const XDaysBeforeAnonymization = site.config.anonymize && (site.config.anonymize.anonymizeUsersAfterXDaysOfInactivity - site.config.anonymize.warnUsersAfterXDaysOfInactivity) || 60;
 
   let data    = {
     date: new Date(),
@@ -237,7 +238,8 @@ function sendInactiveWarningEmail(site, user) {
     SITENAME: sitename,
     URL: url,
     EMAIL: fromAddress,
-    logo: logo
+    logo: logo,
+    XDaysBeforeAnonymization,
   };
 
   let template = site.config.anonymize.inactiveWarningEmail.template;

--- a/src/lib/mail.js
+++ b/src/lib/mail.js
@@ -216,9 +216,61 @@ function sendNewsletterSignupConfirmationMail( newslettersignup, site, user ) {
 
 }
 
+// send email to user that is about to be anonymized
+// todo: this is a copy of sendThankYouMail and has too many code duplications; that should be merged. But since there is a new notification system that should be implemented more widly I am not going to spent time on that now
+function sendInactiveWarningEmail(site, user) {
+
+  let siteConfig = new MailConfig(site)
+
+  const url         = siteConfig.getCmsUrl();
+  const hostname    = siteConfig.getCmsHostname();
+  const sitename    = siteConfig.getTitle();
+  let fromAddress   = site.config.notifications.fromAddress || config.email;
+  if (!fromAddress) return console.error('Email error: fromAddress not provided');
+  if (fromAddress.match(/^.+<(.+)>$/, '$1')) fromAddress = fromAddress.replace(/^.+<(.+)>$/, '$1');
+  const logo =  siteConfig.getLogo();
+
+  let data    = {
+    date: new Date(),
+    user: user,
+    HOSTNAME: hostname,
+    SITENAME: sitename,
+    URL: url,
+    EMAIL: fromAddress,
+    logo: logo
+  };
+
+  let template = site.config.anonymize.inactiveWarningEmail.template;
+  let html = nunjucks.renderString(template, data);
+
+  let text = htmlToText.fromString(html, {
+    ignoreImage: true,
+    hideLinkHrefIfSameAsText: true,
+    uppercaseHeadings: false
+  });
+
+  let attachments = siteConfig.getResourceFeedbackEmailAttachments('idea') || siteConfig.getDefaultEmailAttachments();
+
+  try {
+    sendMail(site, {
+      to: user.email,
+      from: fromAddress,
+      subject: site.config.anonymize.inactiveWarningEmail.subject || 'Je account wordt binnenkort verwijderd',
+      html: html,
+      text: text,
+      attachments,
+    });
+  } catch(err) {
+    console.log(err);
+  }
+
+}
+
+
 module.exports = {
   sendMail,
 	sendNotificationMail,
   sendThankYouMail,
 	sendNewsletterSignupConfirmationMail,
+  sendInactiveWarningEmail,
 };

--- a/src/lib/use-lock.js
+++ b/src/lib/use-lock.js
@@ -1,0 +1,45 @@
+const db	= require('../db');
+
+let useLock = {};
+
+useLock.executeLockedFunction = async function({ name, task }) {
+
+  // use transactions
+  let transaction = await db.sequelize.transaction();
+  let lock;
+
+  try {
+    
+    // create lock
+    lock = await db.Lock.findOne({ type: name })
+    if (lock) {
+      await transaction.rollback();
+      return console.log(`LOCKED FUNCTION NOT RUNNING: ${ name } is locked`)
+    } else {
+      lock = await db.Lock.create({ type: name });
+    }
+
+    // execute task
+    let error = await new Promise( task );
+    if (error) throw error
+
+    await lock.destroy();
+    await transaction.commit();
+
+  } catch(err) {
+    await lock.destroy();
+    await transaction.rollback();
+    console.log(`LOCKED FUNCTION FAILED: ${ name }`);
+    console.log(err);
+  }
+
+}
+
+useLock.createLockedExecutable = function({ name, task }) {
+
+  return async function() {
+    return useLock.executeLockedFunction({ name, task })
+  }
+}
+
+module.exports = exports = useLock;

--- a/src/models/ArgumentVote.js
+++ b/src/models/ArgumentVote.js
@@ -47,15 +47,15 @@ module.exports = function( db, sequelize, DataTypes ) {
 				ArgumentVote.belongsTo(models.User);
 			}
 
-	ArgumentVote.anonimizeOldVotes = function() {
-		var anonimizeThreshold = config.get('ideas.anonimizeThreshold');
+	ArgumentVote.anonymizeOldVotes = function() {
+		var anonymizeThreshold = config.get('ideas.anonymizeThreshold');
 		return sequelize.query(`
 					UPDATE
 						argument_votes v
 					SET
 						v.ip = NULL
 					WHERE
-						DATEDIFF(NOW(), v.updatedAt) > ${anonimizeThreshold} AND
+						DATEDIFF(NOW(), v.updatedAt) > ${anonymizeThreshold} AND
 						checked != 0
 				`)
 			.then(function([ result, metaData ]) {

--- a/src/models/Lock.js
+++ b/src/models/Lock.js
@@ -4,7 +4,11 @@ module.exports = function( db, sequelize, DataTypes ) {
     type: {
       type: DataTypes.STRING,
       allowNull: false,
-    },
+    }
+
+  },{
+
+    paranoid: false
 
   });
 

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -225,7 +225,7 @@ module.exports = function (db, sequelize, DataTypes) {
               },
               template: {
                 type: 'string',
-                default: 'Je account op {{URL}} is verlopen. We gaan je account verwijderen. Als je dat niet wilt, log dan binnen 60 dagemn in.',
+                default: 'Je account op {{URL}} is verlopen. We gaan je account verwijderen. Als je dat niet wilt, log dan binnen 60 dagen in.',
               },
             },
           },

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -191,6 +191,37 @@ module.exports = function (db, sequelize, DataTypes) {
         },
       },
 
+      anonymize: {
+        type: 'object',
+        subset: {
+          anonimizeUsersXDaysAfterEndDate: {
+            type: 'int',
+            default: 60,
+          },
+          warnUsersAfterXDaysOfInactivity: {
+            type: 'int',
+            default: 770,
+          },
+          anonimizeUsersAfterXDaysOfInactivity: {
+            type: 'int',
+            default: 860,
+          },
+          inactiveWarningEmail: {
+            type: 'object',
+            subset: {
+              subject: {
+                type: 'string',
+                default: undefined,
+              },
+              template: {
+                type: 'string',
+                default: undefined,
+              },
+            },
+          },
+        },
+      },
+
       basicAuth: {
         type: 'object',
         subset: {

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -190,6 +190,10 @@ module.exports = function (db, sequelize, DataTypes) {
             type: 'string', // todo: add date type
             default: null,
           },
+          endDateNotificationSent: {
+            type: 'boolean',
+            default: false,
+          },
         },
       },
 

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -166,18 +166,31 @@ module.exports = function (db, sequelize, DataTypes) {
     // todo: formaat gelijktrekken met sequelize defs
     // todo: je zou ook opties kunnen hebben die wel een default hebbe maar niet editable zijn? apiUrl bijv. Of misschien is die afgeleid
     return {
+
       allowedDomains: {
         type: 'arrayOfStrings',
         default: [
           'openstad-api.amsterdam.nl'
         ]
       },
+
       allowedDomains: {
         type: 'arrayOfStrings',
         default: [
           'openstad-api.amsterdam.nl'
         ]
       },
+
+      project: {
+        type: 'object',
+        subset: {
+          endDate: {
+            type: 'string', // todo: add date type
+            default: null,
+          },
+        },
+      },
+
       basicAuth: {
         type: 'object',
         subset: {
@@ -195,6 +208,7 @@ module.exports = function (db, sequelize, DataTypes) {
           },
         }
       },
+
       cms: {
         type: 'object',
         subset: {
@@ -237,6 +251,7 @@ module.exports = function (db, sequelize, DataTypes) {
           }
         }
       },
+
       notifications: {
         type: 'object',
         subset: {
@@ -250,6 +265,7 @@ module.exports = function (db, sequelize, DataTypes) {
           },
         }
       },
+
       email: {
         type: 'object',
         subset: {

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -158,6 +158,7 @@ module.exports = function (db, sequelize, DataTypes) {
   }
 
   Site.associate = function (models) {
+    this.hasMany(models.User);
     this.hasMany(models.Idea);
     this.belongsTo(models.Area);
   }

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -204,7 +204,7 @@ module.exports = function (db, sequelize, DataTypes) {
       anonymize: {
         type: 'object',
         subset: {
-          anonimizeUsersXDaysAfterEndDate: {
+          anonymizeUsersXDaysAfterEndDate: {
             type: 'int',
             default: 60,
           },
@@ -212,7 +212,7 @@ module.exports = function (db, sequelize, DataTypes) {
             type: 'int',
             default: 770,
           },
-          anonimizeUsersAfterXDaysOfInactivity: {
+          anonymizeUsersAfterXDaysOfInactivity: {
             type: 'int',
             default: 860,
           },
@@ -225,7 +225,7 @@ module.exports = function (db, sequelize, DataTypes) {
               },
               template: {
                 type: 'string',
-                default: 'Je account op {{URL}} is verlopen. We gaan je account verwijderen. Als je dat niet wilt, log dan binnen 60 dagen in.',
+                default: 'Je account op {{URL}} is verlopen. We gaan je account verwijderen. Als je dat niet wilt, log dan binnen {{XDaysBeforeAnonymization}} dagen in.',
               },
             },
           },
@@ -977,7 +977,7 @@ module.exports = function (db, sequelize, DataTypes) {
     createableBy: 'admin',
     updateableBy: 'admin',
     deleteableBy: 'admin',
-    canAnonimizeAllUsers : function(user, self) {
+    canAnonymizeAllUsers : function(user, self) {
       self = self || this;
       if (!user) user = self.auth && self.auth.user;
       if (!user || !user.role) user = { role: 'all' };

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -213,11 +213,11 @@ module.exports = function (db, sequelize, DataTypes) {
             subset: {
               subject: {
                 type: 'string',
-                default: undefined,
+                default: 'Je account is verlopen',
               },
               template: {
                 type: 'string',
-                default: undefined,
+                default: 'Je account op {{URL}} is verlopen. We gaan je account verwijderen. Als je dat niet wilt, log dan binnen 60 dagemn in.',
               },
             },
           },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -388,29 +388,35 @@ module.exports = function (db, sequelize, DataTypes) {
         zipCode = zipCode ? String(zipCode).trim() : null;
         this.setDataValue('zipCode', zipCode);
       },
+    },
 
-      postcode: {
-        type: DataTypes.STRING(10),
-        auth: {
-          listableBy: ['moderator', 'owner'],
-          viewableBy: ['moderator', 'owner'],
-          createableBy: ['moderator', 'owner'],
-          updateableBy: ['moderator', 'owner'],
-        },
-        allowNull: true,
-        validate: {
-          is: {
-            args: [/^\d{4} ?[a-zA-Z]{2}$/],
-            msg: 'Ongeldige postcode'
-          }
-        },
-        set: function (zipCode) {
-          zipCode = zipCode != null ?
-            String(zipCode).trim() :
-            null;
-          this.setDataValue('zipCode', zipCode);
-        },
+    postcode: {
+      type: DataTypes.STRING(10),
+      auth: {
+        listableBy: ['moderator', 'owner'],
+        viewableBy: ['moderator', 'owner'],
+        createableBy: ['moderator', 'owner'],
+        updateableBy: ['moderator', 'owner'],
       },
+      allowNull: true,
+      validate: {
+        is: {
+          args: [/^\d{4} ?[a-zA-Z]{2}$/],
+          msg: 'Ongeldige postcode'
+        }
+      },
+      set: function (zipCode) {
+        zipCode = zipCode != null ?
+          String(zipCode).trim() :
+          null;
+        this.setDataValue('zipCode', zipCode);
+      },
+    },
+
+    lastLogin: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: sequelize.NOW,
     },
 
     // signedUpForNewsletter: {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -419,6 +419,12 @@ module.exports = function (db, sequelize, DataTypes) {
       defaultValue: sequelize.NOW,
     },
 
+    isNotifiedAboutAnonymization: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+
     // signedUpForNewsletter: {
     //  	type         : DataTypes.BOOLEAN,
     //  	allowNull    : false,

--- a/src/models/Vote.js
+++ b/src/models/Vote.js
@@ -88,15 +88,15 @@ module.exports = function( db, sequelize, DataTypes ) {
 		}
 	}
 
-	Vote.anonimizeOldVotes = function() {
-		var anonimizeThreshold = config.get('ideas.anonimizeThreshold');
+	Vote.anonymizeOldVotes = function() {
+		var anonymizeThreshold = config.get('ideas.anonymizeThreshold');
 		return sequelize.query(`
 					UPDATE
 						votes v
 					SET
 						v.ip = NULL
 					WHERE
-						DATEDIFF(NOW(), v.updatedAt) > ${anonimizeThreshold} AND
+						DATEDIFF(NOW(), v.updatedAt) > ${anonymizeThreshold} AND
 						checked != 0
 				`)
 			.then(function([ result, metaData ]) {

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -76,8 +76,8 @@ Notifications.sendMessage = function(siteId, type, action, data) {
 
 			maildata.subject = type == 'argument' ? 'Nieuwe argumenten geplaatst' : ( action == 'create' ? 'Nieuwe inzending geplaatst' : 'Bestaande inzending bewerkt' );
 
-			maildata.from = ( myConfig.notifications && ( myConfig.notifications.from || ( myConfig.notifications.admin && myConfig.notifications.admin.emailAddress ) ) ) || myConfig.mail.from; // backwards compatible
-			maildata.to = ( myConfig.notifications && myConfig.notifications.to ) || maildata.from;
+			maildata.from = ( myConfig.notifications && myConfig.notifications.fromAddress ) || myConfig.mail.from;
+			maildata.to = ( myConfig.notifications && myConfig.notifications.projectmanagerAddress );
 
 			maildata.EMAIL = maildata.from;
 			maildata.HOSTNAME = ( myConfig.cms && ( myConfig.cms.hostname || myConfig.cms.domain ) ) || myConfig.hostname || myConfig.domain;

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -69,7 +69,6 @@ Notifications.sendMessage = function(siteId, type, action, data) {
 	db.Site.findByPk(siteId)
 		.then(site => {
 
-      
 			let myConfig = Object.assign({}, config, site && site.config);
 
 			let maildata = {};

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -2,128 +2,128 @@ const config = require('config');
 const mail = require('../lib/mail');
 
 let Notifications = {
-	queue: {},
+  queue: {},
 };
 
 Notifications.addToQueue = function(content) {
 
-	let self = this;
+  let self = this;
 
-	if (!content.type || !content.instanceId) return;
+  if (!content.type || !content.instanceId) return;
 
-	self.queue[content.type] = self.queue[content.type] || {};
-	self.queue[content.type][content.siteId] = self.queue[content.type][content.siteId] || [];
-	
-	self.queue[content.type][content.siteId].push(content);
+  self.queue[content.type] = self.queue[content.type] || {};
+  self.queue[content.type][content.siteId] = self.queue[content.type][content.siteId] || [];
+  
+  self.queue[content.type][content.siteId].push(content);
 
 
 }
 
 Notifications.processQueue = function(type) {
 
-	let self = this;
+  let self = this;
   
-	if (self.queue[type]) {
+  if (self.queue[type]) {
 
-		Object.keys(self.queue[type]).forEach((siteId) => {
+    Object.keys(self.queue[type]).forEach((siteId) => {
 
-			if (self.queue[type][siteId] && self.queue[type][siteId].length) {
+      if (self.queue[type][siteId] && self.queue[type][siteId].length) {
 
-				switch(type) {
-					case 'argument':
-						self.sendNewContentMessage({siteId, type: 'argument', action: 'create', content: self.queue[type][siteId] });
-						break;
+        switch(type) {
+          case 'argument':
+            self.sendNewContentMessage({siteId, type: 'argument', action: 'create', content: self.queue[type][siteId] });
+            break;
 
-					case 'idea':
-						self.queue[type][siteId].forEach((entry) => {
-							self.sendNewContentMessage({siteId, type: 'idea', action: entry.action, content: [entry] });
-						});
-						break;
+          case 'idea':
+            self.queue[type][siteId].forEach((entry) => {
+              self.sendNewContentMessage({siteId, type: 'idea', action: entry.action, content: [entry] });
+            });
+            break;
 
-					case 'article':
-						self.queue[type][siteId].forEach((entry) => {
-							self.sendNewContentMessage({siteId, type: 'article', action: entry.action, content: [entry] });
-						});
-						break;
-						
-					default: 
-				}
+          case 'article':
+            self.queue[type][siteId].forEach((entry) => {
+              self.sendNewContentMessage({siteId, type: 'article', action: entry.action, content: [entry] });
+            });
+            break;
+            
+          default: 
+        }
 
-				self.queue[type][siteId] = [];
+        self.queue[type][siteId] = [];
 
-			}
+      }
 
-		});
+    });
 
-	}
+  }
 
 }
 
 Notifications.sendNewContentMessage = function({ siteId, type, action, content }) {
 
-	const db = require('../db'); // looped required
+  const db = require('../db'); // looped required
 
-	let self = this;
+  let self = this;
 
-	// get config
-	db.Site.findByPk(siteId)
+  // get config
+  db.Site.findByPk(siteId)
 
-		.then(site => {
+    .then(site => {
 
-			let myConfig = Object.assign({}, config, site && site.config);
+      let myConfig = Object.assign({}, config, site && site.config);
 
-			let data = {};
+      let data = {};
 
-			data.subject = ( type == 'argument' ? 'Nieuwe argumenten geplaatst' : ( action == 'create' ? 'Nieuwe inzending geplaatst' : 'Bestaande inzending bewerkt' ) );
-			data.SITENAME = ( site && site.title ) || myConfig.siteName;
-			data.subject += ' op ' + data.SITENAME;
+      data.subject = ( type == 'argument' ? 'Nieuwe argumenten geplaatst' : ( action == 'create' ? 'Nieuwe inzending geplaatst' : 'Bestaande inzending bewerkt' ) );
+      data.SITENAME = ( site && site.title ) || myConfig.siteName;
+      data.subject += ' op ' + data.SITENAME;
 
-			data.template = myConfig.notifications && myConfig.notifications.template;
+      data.template = myConfig.notifications && myConfig.notifications.template;
 
-			let instanceIds = content.map( entry => entry.instanceId );
-			let model = type.charAt(0).toUpperCase() + type.slice(1);
+      let instanceIds = content.map( entry => entry.instanceId );
+      let model = type.charAt(0).toUpperCase() + type.slice(1);
 
-			let scope = type == 'idea' || type == 'article' ? ['withUser'] : ['withUser', 'withIdea'];
+      let scope = type == 'idea' || type == 'article' ? ['withUser'] : ['withUser', 'withIdea'];
       scope.push('includeSite');
-			db[model].scope(scope).findAll({ where: { id: instanceIds }})
-				.then( found => {
-					data.data = {};
-					data.data[type] = found.map( entry => {
-						let json = entry.toJSON();
-						if ( type == 'idea' ) {
-							let inzendingPath = ( myConfig.ideas && myConfig.ideas.feedbackEmail && myConfig.ideas.feedbackEmail.inzendingPath && myConfig.ideas.feedbackEmail.inzendingPath.replace(/\[\[ideaId\]\]/, entry.id) ) || "/";
-							json.inzendingURL = data.URL + inzendingPath;
-						}
-						if ( type == 'article' ) {
-							let inzendingPath = ( myConfig.articles && myConfig.articles.feedbackEmail && myConfig.articles.feedbackEmail.inzendingPath && myConfig.articles.feedbackEmail.inzendingPath.replace(/\[\[articleId\]\]/, entry.id) ) || "/";
-							json.inzendingURL = data.URL + inzendingPath;
-						}
-						return json;
-					});
-					Notifications.sendMessage({ site, data });
-				});
+      db[model].scope(scope).findAll({ where: { id: instanceIds }})
+        .then( found => {
+          data.data = {};
+          data.data[type] = found.map( entry => {
+            let json = entry.toJSON();
+            if ( type == 'idea' ) {
+              let inzendingPath = ( myConfig.ideas && myConfig.ideas.feedbackEmail && myConfig.ideas.feedbackEmail.inzendingPath && myConfig.ideas.feedbackEmail.inzendingPath.replace(/\[\[ideaId\]\]/, entry.id) ) || "/";
+              json.inzendingURL = data.URL + inzendingPath;
+            }
+            if ( type == 'article' ) {
+              let inzendingPath = ( myConfig.articles && myConfig.articles.feedbackEmail && myConfig.articles.feedbackEmail.inzendingPath && myConfig.articles.feedbackEmail.inzendingPath.replace(/\[\[articleId\]\]/, entry.id) ) || "/";
+              json.inzendingURL = data.URL + inzendingPath;
+            }
+            return json;
+          });
+          Notifications.sendMessage({ site, data });
+        });
 
-		})
+    })
 
 }
 
 Notifications.sendMessage = function({ site, data }) {
 
-	let self = this;
-	let myConfig = Object.assign({}, config, site && site.config);
+  let self = this;
+  let myConfig = Object.assign({}, config, site && site.config);
 
-	data.from = data.from || ( myConfig.notifications && myConfig.notifications.fromAddress ) || myConfig.mail.from;
-	data.to = data.to || ( myConfig.notifications && myConfig.notifications.projectmanagerAddress );
+  data.from = data.from || ( myConfig.notifications && myConfig.notifications.fromAddress ) || myConfig.mail.from;
+  data.to = data.to || ( myConfig.notifications && myConfig.notifications.projectmanagerAddress );
 
-	data.EMAIL = data.EMAIL || data.from;
-	data.HOSTNAME = data.HOSTNAME || ( myConfig.cms && ( myConfig.cms.hostname || myConfig.cms.domain ) ) || myConfig.hostname || myConfig.domain;
-	data.URL = data.URL || ( myConfig.cms && myConfig.cms.url ) || myConfig.url || ( 'https://' + data.HOSTNAME );
-	data.SITENAME = data.SITENAME || ( site && site.title ) || myConfig.siteName;
+  data.EMAIL = data.EMAIL || data.from;
+  data.HOSTNAME = data.HOSTNAME || ( myConfig.cms && ( myConfig.cms.hostname || myConfig.cms.domain ) ) || myConfig.hostname || myConfig.domain;
+  data.URL = data.URL || ( myConfig.cms && myConfig.cms.url ) || myConfig.url || ( 'https://' + data.HOSTNAME );
+  data.SITENAME = data.SITENAME || ( site && site.title ) || myConfig.siteName;
 
-	data.subject = data.subject || 'Geen onderwerp';
-	data.template = data.template;
+  data.subject = data.subject || 'Geen onderwerp';
+  data.template = data.template;
 
-	mail.sendNotificationMail(data, site);
+  mail.sendNotificationMail(data, site);
 
 }
 

--- a/src/routes/api/site.js
+++ b/src/routes/api/site.js
@@ -41,12 +41,7 @@ router.route('/')
 	.get(pagination.init)
 	.get(function(req, res, next) {
 
-		const scope = [];
-    if (req.query.includeAdminTriggers) {
-      scope.push('includeAdminTriggers');
-    } else {
-      scope.push('withArea');
-    }
+		const scope = ['withArea'];
 
 		db.Site
 			.scope(scope)

--- a/src/routes/api/site.js
+++ b/src/routes/api/site.js
@@ -128,7 +128,9 @@ router.route('/issues')
               }
             }, {
               config: {
-                projectHasEnded: false,
+                project: {
+                  projectHasEnded: false,
+                }
               }
             }              
           ]

--- a/src/routes/api/site.js
+++ b/src/routes/api/site.js
@@ -112,8 +112,8 @@ router.route('/issues')
 	})
 	.get(function(req, res, next) {
 
-    // sites that have ended but are not anonimized
-    sitesWithIssues.endedButNotAnonimized({ offset: req.dbQuery.offset, limit: req.dbQuery.limit })
+    // sites that have ended but are not anonymized
+    sitesWithIssues.endedButNotAnonymized({ offset: req.dbQuery.offset, limit: req.dbQuery.limit })
 			.then( result => {
         req.results = req.results.concat( result.rows );
         req.dbQuery.count += result.count;
@@ -272,7 +272,7 @@ router.route('/:siteIdOrDomain') //(\\d+)
 // anonymize all users
 // -------------------
 router.route('/:siteId(\\d+)/:willOrDo(will|do)-anonymize-all-users')
-	.put(auth.can('Site', 'anonimizeAllUsers'))
+	.put(auth.can('Site', 'anonymizeAllUsers'))
 	.put(function(req, res, next) {
     // the site
 		let where = { id: parseInt(req.params.siteId) };

--- a/src/routes/api/user.js
+++ b/src/routes/api/user.js
@@ -230,7 +230,7 @@ router.route('/:userId(\\d+)/:willOrDo(will|do)-anonymize(:all(all)?)')
       .catch(next);
   })
   .put(async function (req, res, next) {
-    // if body contains user ids then anonimize only those
+    // if body contains user ids then anonymize only those
     try {
       let ids = req.body && req.body.onlyUserIds;
       if (!ids) return next();
@@ -243,7 +243,7 @@ router.route('/:userId(\\d+)/:willOrDo(will|do)-anonymize(:all(all)?)')
     return next();
   })
   .put(async function (req, res, next) {
-    // if body contains site ids then anonimize only the users for those sites
+    // if body contains site ids then anonymize only the users for those sites
     try {
       let ids = req.body && req.body.onlySiteIds;
       if (!ids) return next();

--- a/src/routes/oauth/oauth.js
+++ b/src/routes/oauth/oauth.js
@@ -160,6 +160,7 @@ router
             lastName: req.userData.lastName,
             role: req.userData.role || ((req.userData.email || req.userData.phoneNumber || req.userData.hashedPhoneNumber) ? 'member' : 'anonymous'),
             lastLogin: new Date(),
+            isNotifiedAboutAnonymization: null,
         }
 
         // if user has same siteId and userId

--- a/src/routes/oauth/oauth.js
+++ b/src/routes/oauth/oauth.js
@@ -158,8 +158,8 @@ router
             zipCode: req.userData.postcode ? req.userData.postcode : null,
             postcode: req.userData.postcode ? req.userData.postcode : null,
             lastName: req.userData.lastName,
-            // xxx
             role: req.userData.role || ((req.userData.email || req.userData.phoneNumber || req.userData.hashedPhoneNumber) ? 'member' : 'anonymous'),
+            lastLogin: new Date(),
         }
 
         // if user has same siteId and userId

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -15,12 +15,12 @@ module.exports = {
 
     const data = {};
     data.to = recipient.email;
-    data.from = ( myConfig.notifications && ( myConfig.notifications.from || ( myConfig.notifications.admin && myConfig.notifications.admin.emailAddress ) ) ) || myConfig.mail.from; // Todo: move to helper method
+    data.from = ( myConfig.notifications && myConfig.notifications.fromAddress ) || myConfig.mail.from;
     data.subject = emailData.subject;
 
     data.EMAIL = data.from;
     data.HOSTNAME = ( myConfig.cms && ( myConfig.cms.hostname || myConfig.cms.domain ) ) || myConfig.hostname || myConfig.domain;
-    data.URL = ( myConfig.cms && myConfig.cms.url ) || myConfig.url || ( 'https://' + maildata.HOSTNAME );
+    data.URL = ( myConfig.cms && myConfig.cms.url ) || myConfig.url || ( 'https://' + emailData.HOSTNAME );
     data.SITENAME = ( site && site.title ) || myConfig.siteName;
 
     emailData.SITENAME = data.SITENAME;

--- a/src/services/sites-with-issues.js
+++ b/src/services/sites-with-issues.js
@@ -1,0 +1,73 @@
+const Sequelize = require('sequelize');
+const db = require('../db');
+
+let sitesWithIssues = {};
+
+sitesWithIssues.shouldHaveEndedButAreNot = function({ offset, limit }) {
+  return db.Site
+    .findAndCountAll({
+      offset, limit,
+      attributes: { 
+        include: [
+          [Sequelize.literal('"Site endDate is in the past but projectHasEnded is not set"'), 'issue'],
+        ],
+      },
+      where: {
+        [Sequelize.Op.and]: [
+          {
+            config: {
+              project: {
+                endDate: {
+                  [Sequelize.Op.not]: null
+                }
+              }
+            }
+          }, {
+            config: {
+              project: {
+                endDate: {
+                  [Sequelize.Op.lte]: new Date(),
+                }
+              }
+            }
+          }, {
+            config: {
+              project: {
+                projectHasEnded: false,
+              }
+            }
+          }              
+        ]
+      }
+    })
+}
+
+sitesWithIssues.endedButNotAnonimized = function({ offset, limit }) {
+  return db.Site
+	  .findAndCountAll({
+      offset, limit,
+      attributes: { 
+        include: [
+          [Sequelize.literal('"Project has ended but is not yet anonimized"'), 'issue'],
+          [Sequelize.fn("COUNT", Sequelize.col("users.id")), "userCount"]
+        ],
+      },
+      include: [{
+        model: db.User,
+        attributes: [],
+        where: {
+          role: 'member',
+        }
+      }],
+      group: ['users.siteId'],
+      where: {
+			  [Sequelize.Op.and]: [
+				  // where site enddate is more then anonimizeUsersXDaysAfterEndDate days ago
+				  Sequelize.literal("DATE_ADD(CAST(JSON_UNQUOTE(JSON_EXTRACT(site.config,'$.project.endDate')) as DATETIME), INTERVAL json_extract(site.config, '$.anonymize.anonimizeUsersXDaysAfterEndDate') DAY) < NOW()"),
+          { config: { projectHasEnded: true } },
+			  ]
+		  }
+    })
+}
+
+module.exports = exports = sitesWithIssues;

--- a/src/services/sites-with-issues.js
+++ b/src/services/sites-with-issues.js
@@ -42,13 +42,13 @@ sitesWithIssues.shouldHaveEndedButAreNot = function({ offset, limit }) {
     })
 }
 
-sitesWithIssues.endedButNotAnonimized = function({ offset, limit }) {
+sitesWithIssues.endedButNotAnonymized = function({ offset, limit }) {
   return db.Site
     .findAndCountAll({
       offset, limit,
       attributes: { 
         include: [
-          [Sequelize.literal('"Project has ended but is not yet anonimized"'), 'issue'],
+          [Sequelize.literal('"Project has ended but is not yet anonymized"'), 'issue'],
           [Sequelize.fn("COUNT", Sequelize.col("users.id")), "userCount"]
         ],
       },
@@ -62,8 +62,8 @@ sitesWithIssues.endedButNotAnonimized = function({ offset, limit }) {
       group: ['users.siteId'],
       where: {
         [Sequelize.Op.and]: [
-          // where site enddate is more then anonimizeUsersXDaysAfterEndDate days ago
-          Sequelize.literal("DATE_ADD(CAST(JSON_UNQUOTE(JSON_EXTRACT(site.config,'$.project.endDate')) as DATETIME), INTERVAL json_extract(site.config, '$.anonymize.anonimizeUsersXDaysAfterEndDate') DAY) < NOW()"),
+          // where site enddate is more then anonymizeUsersXDaysAfterEndDate days ago
+          Sequelize.literal("DATE_ADD(CAST(JSON_UNQUOTE(JSON_EXTRACT(site.config,'$.project.endDate')) as DATETIME), INTERVAL json_extract(site.config, '$.anonymize.anonymizeUsersXDaysAfterEndDate') DAY) < NOW()"),
           { config: { projectHasEnded: true } },
         ]
       }

--- a/src/services/sites-with-issues.js
+++ b/src/services/sites-with-issues.js
@@ -44,7 +44,7 @@ sitesWithIssues.shouldHaveEndedButAreNot = function({ offset, limit }) {
 
 sitesWithIssues.endedButNotAnonimized = function({ offset, limit }) {
   return db.Site
-	  .findAndCountAll({
+    .findAndCountAll({
       offset, limit,
       attributes: { 
         include: [
@@ -61,12 +61,12 @@ sitesWithIssues.endedButNotAnonimized = function({ offset, limit }) {
       }],
       group: ['users.siteId'],
       where: {
-			  [Sequelize.Op.and]: [
-				  // where site enddate is more then anonimizeUsersXDaysAfterEndDate days ago
-				  Sequelize.literal("DATE_ADD(CAST(JSON_UNQUOTE(JSON_EXTRACT(site.config,'$.project.endDate')) as DATETIME), INTERVAL json_extract(site.config, '$.anonymize.anonimizeUsersXDaysAfterEndDate') DAY) < NOW()"),
+        [Sequelize.Op.and]: [
+          // where site enddate is more then anonimizeUsersXDaysAfterEndDate days ago
+          Sequelize.literal("DATE_ADD(CAST(JSON_UNQUOTE(JSON_EXTRACT(site.config,'$.project.endDate')) as DATETIME), INTERVAL json_extract(site.config, '$.anonymize.anonimizeUsersXDaysAfterEndDate') DAY) < NOW()"),
           { config: { projectHasEnded: true } },
-			  ]
-		  }
+        ]
+      }
     })
 }
 


### PR DESCRIPTION
# Description

Anonimize site users contains two main parts:
- make sure that siteadmins or project managers anonymize old sites
- remove users that have been inactive for a certain amount of time

To do this the following changes have been made:
- Add project.endDate to site.config
- Add anonymize settings to site.config, i.e. some timers on when to anoymize users
- Add extra noticications layer to site.config, i.e. split the one existing 'to' email address into two: one for a projectmanager, and one for a site admin.
- Add lastLogin to user
- Add sites-with-issues route
- Add cron to automatically warn and anonymize inactive users
- Add cron to automatically notify about project enddate
- Add cron to automatically notify about sites-with-issues
- Add generic lock use - fixes [issue #255](https://github.com/openstad/openstad-api/issues/255)
- Remove sequelize.paranoid from locks
- Refactor: Move site.config.projectHasEnded to site.config.project.projectHasEnded

## Issue reference

It does, incidentally, fix [issue #255](https://github.com/openstad/openstad-api/issues/255)

## Type of change

New feature

## Documentation

Documentation has not been written yet; this will hopefully be done before this code is merged

## See also
[issue #256](https://github.com/openstad/openstad-api/issues/256)
https://github.com/openstad/openstad-management-panel/pull/76
https://github.com/openstad/openstad-react-admin/pull/14