### PR TITLE
Fix the backwards compatibility for site.config.projectHasEnded

### DIFF
--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -820,10 +820,13 @@ Wil je dit liever niet? Dan hoef je alleen een keer in te loggen op de website o
         }
 
         // backwards compatibility projectHasEnded
-        if (key == 'project' && value[key] && typeof value[key].projectHasEnded == 'undefined' && typeof value.projectHasEnded != 'undefined') {
-          // dit is een oude
-          value[key].projectHasEnded = value.projectHasEnded;
-          delete value.projectHasEnded
+        if (key == 'project') {
+          value[key] = value[key] || {};
+          if (typeof value[key].projectHasEnded == 'undefined' && typeof value.projectHasEnded != 'undefined') {
+            // dit is een oude
+            value[key].projectHasEnded = value.projectHasEnded;
+            delete value.projectHasEnded
+          }
         }
 
         // TODO: 'arrayOfObjects' met een subset


### PR DESCRIPTION
# Bugfix

The config value projectHasEnded was moved from the root of the config to the project tree. Backwards compatibility wasn't working properly.