### PR TITLE
Make locks type unique

### DIFF
--- a/migrations/040-locks-type-unique.js
+++ b/migrations/040-locks-type-unique.js
@@ -1,0 +1,15 @@
+let db = require('../src/db').sequelize;
+
+module.exports = {
+  up: function() {
+
+    try {
+      return db.query(`
+        ALTER TABLE locks ADD UNIQUE uniqueLocksType (type); 
+			`);
+    } catch(e) {
+      return true;
+    }
+
+  }
+}

--- a/src/lib/use-lock.js
+++ b/src/lib/use-lock.js
@@ -4,16 +4,12 @@ let useLock = {};
 
 useLock.executeLockedFunction = async function({ name, task }) {
 
-  // use transactions
-  let transaction = await db.sequelize.transaction();
   let lock;
-
   try {
     
     // create lock
     lock = await db.Lock.findOne({where: { type: name }})
     if (lock) {
-      await transaction.rollback();
       return console.log(`LOCKED FUNCTION NOT RUNNING: ${ name } is locked`)
     } else {
       lock = await db.Lock.create({ type: name });
@@ -24,22 +20,23 @@ useLock.executeLockedFunction = async function({ name, task }) {
     if (error) throw error
 
     await lock.destroy();
-    await transaction.commit();
 
   } catch(err) {
     if(lock) {
       await lock.destroy();
     }
-  
-    await transaction.rollback();
-    console.log(`LOCKED FUNCTION FAILED: ${ name }`);
-    console.log(err);
+
+    if (err.name == 'SequelizeUniqueConstraintError') {
+      return console.log(`LOCKED FUNCTION NOT RUNNING: ${ name } is locked`)
+    } else {
+      return console.log(`LOCKED FUNCTION FAILED: ${ name }`);
+      console.log(err);
+    }
   }
 
 }
 
 useLock.createLockedExecutable = function({ name, task }) {
-
   return async function() {
     return useLock.executeLockedFunction({ name, task })
   }


### PR DESCRIPTION
# Description

The locking mechanism as is does not work as intended. Sequelize transactions do not lock the table, and using seqeulize to create table locks seems only possible with raw queries.

A blunt but effective alternative is used here: make the type field in the locks table unique, and prevent multiple instances by (mis)using mysql's capabilities.

## Issue reference

Fixes #255 

## Type of change

Let's call this a bug fix
