### PR TITLE
Use a correct default for site admin notificatiosn address

### DIFF
--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -309,7 +309,7 @@ Wil je dit liever niet? Dan hoef je alleen een keer in te loggen op de website o
           },
           siteadminAddress: {
             type: 'string', // todo: add type email/list of emails
-            default: 'EMAIL@NOT.DEFINED',
+            default: apiConfig.notifications.admin.emailAddress,
           },
         },
       },


### PR DESCRIPTION
When emptying `site.config.notifications.admin.emailAddress` the field should default to the globally defined adderss.

This is now so.