### PR TITLE
Feature/import with tags through admin panel

### DIFF
--- a/src/routes/api/idea.js
+++ b/src/routes/api/idea.js
@@ -412,6 +412,8 @@ router.route('/:ideaId(\\d+)')
   });
 
 
+  // This function is used with import/create and import/update of ideas. 
+  // Because an exported idea can only have names we need to figure out which names exists on tags on the siteId and which need to be created
   const getOrCreateTagIds = async function(siteId, tags) {
     let tagIdsToAdd = [];
     const tagsOfSite = await db.Tag.findAll({where: { siteId }});

--- a/src/routes/api/idea.js
+++ b/src/routes/api/idea.js
@@ -221,16 +221,17 @@ router.route('/')
     if (!tags) return next();
     const ideaInstance = req.results;
     const siteId = req.params.siteId;
-    // assume we are not using import so the values are ids
-    let tagIdsToAdd = tags;
+    let tagIds = tags;
 
-    // We only have names available to us when we import change them to ids
-    if(req.body.changeTagNamesToIds) {
-      tagIdsToAdd = Array.from(await getOrCreateTagIds(siteId, tags));
+    // should always be an array of either [1,2,3] from openstad
+    // or ['naam'] when importing ideas from react-admin.
+    const isNamePredicate = value => typeof value == 'string' && isNaN(value);
+    if(Array.isArray(tags) && tags.every(isNamePredicate)) {
+      tagIds = Array.from(await getOrCreateTagIds(siteId, tags));
     }
 
     ideaInstance
-      .setTags(tagIdsToAdd)
+      .setTags(tagIds)
       .then(tags => {
         // refetch. now with tags
         let scope = [...req.scope, 'includeTags'];
@@ -360,12 +361,15 @@ router.route('/:ideaId(\\d+)')
     const tags = req.body.tags || req.tags;
     if (!tags) return next();
     let tagIds = tags;
-    let ideaInstance = req.results;
 
-    // We only have names available to us when we import
-    if(req.body.changeTagNamesToIds) {
+    // should always be an array of either [1,2,3] from openstad
+    // or ['naam'] when importing ideas from react-admin.
+    const isNamePredicate = value => typeof value == 'string' && isNaN(value);
+    if(Array.isArray(tags) && tags.every(isNamePredicate)) {
       tagIds = Array.from(await getOrCreateTagIds(siteId, tags));
     }
+
+    let ideaInstance = req.results;
     
     ideaInstance
       .setTags(tagIds)

--- a/src/routes/api/idea.js
+++ b/src/routes/api/idea.js
@@ -225,7 +225,7 @@ router.route('/')
     let tagIdsToAdd = tags;
 
     // We only have names available to us when we import change them to ids
-    if(req.body.throughImport) {
+    if(req.body.changeTagNamesToIds) {
       tagIdsToAdd = Array.from(await getOrCreateTagIds(siteId, tags));
     }
 
@@ -363,7 +363,7 @@ router.route('/:ideaId(\\d+)')
     let ideaInstance = req.results;
 
     // We only have names available to us when we import
-    if(req.body.throughImport) {
+    if(req.body.changeTagNamesToIds) {
       tagIds = Array.from(await getOrCreateTagIds(siteId, tags));
     }
     


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description
Added a key to differentiate when creating an idea is used with the import functionality on the react-admin panel, If it is, check the tagnames given, create the tag for the given siteId if it does not yet exist and set the relation between the idea and the tag. 
