### PR TITLE
Use the correct paramater

### DIFF
--- a/src/routes/api/vote.js
+++ b/src/routes/api/vote.js
@@ -39,7 +39,7 @@ router.route('*')
 	.all(function(req, res, next) {
 		if (req.method == 'GET') return next(); // nvt
 
-		let hasModeratorRights = userhasModeratorRights(req.user.role);
+		let hasModeratorRights = userhasModeratorRights(req.user);
 
 		if (!req.user) {
 			return next(createError(401, 'Geen gebruiker gevonden'));
@@ -77,7 +77,7 @@ router.route('/')
 
 // mag je de stemmen bekijken
 	.get(function(req, res, next) {
-		let hasModeratorRights = userhasModeratorRights(req.user.role);
+		let hasModeratorRights = userhasModeratorRights(req.user);
 
 		if (!(req.site.config.votes.isViewable || hasModeratorRights)) {
 			return next(createError(403, 'Stemmen zijn niet zichtbaar'));


### PR DESCRIPTION
# Description

Recently the show-votes route has been updated: only admins can now see votes. This has been done incorrectly:
The function `userhasModeratorRights(user)` was sometimes used as `userhasModeratorRights(role);`. 

This change fixes that.
