### PR TITLE
Add adminIsNotified to sites and aggregate emails

### DIFF
--- a/migrations/042-add-site-is-notified-field.js
+++ b/migrations/042-add-site-is-notified-field.js
@@ -1,0 +1,15 @@
+let db = require('../src/db').sequelize;
+
+module.exports = {
+  up: function() {
+
+    try {
+      return db.query(`
+        ALTER TABLE sites ADD adminIsNotified DATETIME NULL DEFAULT NULL AFTER areaId; 
+			`);
+    } catch(e) {
+      return true;
+    }
+
+  }
+}

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -67,7 +67,13 @@ module.exports = function (db, sequelize, DataTypes) {
     areaId: {
       type: DataTypes.INTEGER,
       allowNull: true,
-    }
+    },
+
+    adminIsNotified: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      default: null,
+    },
 
   }, {
 


### PR DESCRIPTION
The API sends daily notifications to administrators about sites that have issues.
These notifications have two inconveniences:
- one email is sent for each site with issues
- since crontabs are running on the api: multiple api's means multiple mails

This update adds a 'notificationSent' paramater to fix the second, while the content of emails is aggregated per email address to fix the first.