### PR TITLE
Add check on existing users bofore deleting a site

### DIFF
--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -118,8 +118,18 @@ module.exports = function (db, sequelize, DataTypes) {
         return beforeUpdateOrCreate(instance, options);
       },
 
-      beforeDestroy: function (instance, options) {
+      beforeDestroy: async function (instance, options) {
+        // project has ended
         if (!(instance && instance.config && instance.config.project.projectHasEnded)) throw Error('Cannot delete an active site - first set the project-has-ended parameter');
+        // are all users anonymized
+        let found = await db.User
+            .findAll({
+              where: {
+                siteId: instance.id,
+                role: 'member',
+              }
+            })
+        if (found) throw Error('Cannot delete an active site - first anonymize all users');
         return 
       },
 


### PR DESCRIPTION
When a site is deleted it will leave existing users behind.

These users should have been anonymized. They were not, and will not be found in existing checks.

The easiest fix, and maybe most consistent, is to disabling the deleting of sites that have not been anonymized. That is what is fix does.

By requiring to use the existing anonymize functionality we prevent future mismatches between this and other parts of the code.