### PR TITLE
Feature/allow backup cronjobs to be run by a k8s cronjob ams cp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## UNRELEASED
+* Change mongoDB S3 backup to read the database dump in chunks and upload it to the S3 bucket using a MultiPart upload setup.
+
 ## 1.0.0
 * Anonymize site users 
 * Save idea as concept
@@ -25,7 +28,6 @@ Update version number
 * New template distribution system
 * Do not wait for cms when updating site config
 * Move docker builds from travis to github actions
-
 ## v0.20.0 (2021-12-20)
 * Fix responding to not existing routes with to much information
 * Make submissions listable & viewable, and allow them to be filtered by formId

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 * Change mongoDB S3 backup to read the database dump in chunks and upload it to the S3 bucket using a MultiPart upload setup.
+* Allow s3 backups to be disabled from the cronjobs, but instead be run through a different entrypoint (backup.js) to allow kubernetes cronjobs to be used.
 
 ## 1.0.0
 * Anonymize site users 

--- a/backup.js
+++ b/backup.js
@@ -1,0 +1,27 @@
+const backupMapping = {
+  'mongo': 'mongodb_s3_backups',
+  'mysql': 'mysql_s3_backups'
+};
+
+if (!!process.env.BACKUP_TYPE === false) {
+  console.error ('No backup type given in ENV variables');
+  process.exit(1);
+}
+
+if (Object.keys(backupMapping).indexOf(process.env.BACKUP_TYPE) === -1) {
+  console.error ('Backup type not supported');
+  process.exit(1);
+}
+
+const backup = require(`./src/cron/${backupMapping[process.env.BACKUP_TYPE]}`);
+
+async function run() {
+  try {
+    console.log(`${backupMapping[process.env.BACKUP_TYPE]}`);
+    await backup.onTick();
+  } catch (err) {
+    console.error('Backup went wrong', err);
+  }
+}
+
+run();

--- a/src/cron/mongodb_backups.js
+++ b/src/cron/mongodb_backups.js
@@ -10,6 +10,10 @@ module.exports = {
 	cronTime: '0 0 1 * * *',
 	runOnInit: true,
 	onTick: function() {
+    if (!!process.env.PREVENT_BACKUP_CRONJOBS === true || process.env.S3_MONGO_BACKUPS === 'ON') {
+      return;
+    }
+    
     const objectStoreUrl = process.env.OBJECT_STORE_URL;
     const objectStoreUser = process.env.OBJECT_STORE_USER;
     const objectStorePass = process.env.OBJECT_STORE_PASS;

--- a/src/cron/mongodb_s3_backups.js
+++ b/src/cron/mongodb_s3_backups.js
@@ -5,6 +5,10 @@ const s3     = require('../services/awsS3');
 const util   = require('util');
 
 const backupMongoDBToS3 = async () => {
+  if (!!process.env.PREVENT_BACKUP_CRONJOBS === true) {
+    return;
+  }
+  
   console.log('backing up to mongodb', process.env.S3_MONGO_BACKUPS);
   
   if (process.env.S3_MONGO_BACKUPS === 'ON') {

--- a/src/cron/mongodb_s3_backups.js
+++ b/src/cron/mongodb_s3_backups.js
@@ -2,6 +2,7 @@ const fs     = require('fs');
 const moment = require('moment')
 const {exec} = require('child_process');
 const s3     = require('../services/awsS3');
+const util   = require('util');
 
 const backupMongoDBToS3 = async () => {
   console.log('backing up to mongodb', process.env.S3_MONGO_BACKUPS);
@@ -9,156 +10,43 @@ const backupMongoDBToS3 = async () => {
   if (process.env.S3_MONGO_BACKUPS === 'ON') {
     const host            = process.env.MONGO_DB_HOST || 'localhost';
     const port            = process.env.MONGO_DB_PORT || 27017;
-    const tmpDbFile       = 'db_mongo';
+    const tempFile        = 'db_mongo';
     const isOnK8s         = !!process.env.KUBERNETES_NAMESPACE;
     const namespace       = process.env.KUBERNETES_NAMESPACE;
-    const bucket          = process.env.S3_BUCKET;
-    const removeTmpDbFile = () => {
+    const deleteTempFile = () => {
       try {
-        console.log ('removing tmp db file', tmpDbFile);
-        fs.unlinkSync(tmpDbFile);
+        console.log ('removing temp file', tempFile);
+        fs.unlinkSync(tempFile);
       } catch (e) {
-        console.error('error removing file', e);
+        console.error('error removing file', tempFile, e);
       }
     };
     
     // Default command, does not considers username or password
-    let command = `mongodump -h ${host} --port=${port} --archive=${tmpDbFile}`;
+    let command = `mongodump -h ${host} --port=${port} --archive=${tempFile}`;
     
+    const promiseExec = util.promisify(exec);
     
-    exec(command, async (err, stdout, stderr) => {
+    return promiseExec(command, async (err, stdout, stderr) => {
       if (err) {
         // Most likely, mongodump isn't installed or isn't accessible
         console.error(`mongodump command error: ${err}`);
-        removeTmpDbFile();
+        deleteTempFile();
       } else {
         const created = moment().format('YYYY-MM-DD hh:mm:ss')
         
-        const statsFile = fs.statSync(tmpDbFile);
+        const statsFile = fs.statSync(tempFile);
         console.info(`file size: ${Math.round(statsFile.size / 1024 / 1024)}MB`);
         
         const fileNameInS3 = isOnK8s ? `mongodb/${namespace}/mongo_${created}` : `mongodb/mongo_${created}`;
-        
-        const s3Client = s3.getClient();
-        
-        //  Each part must be at least 5 MB in size, except the last part.
-        let uploadId;
+  
         try {
-          const params = {
-            Bucket: bucket,
-            Key:    fileNameInS3,
-            ACL:    "private"
-          };
-          const result = await s3Client.createMultipartUpload(params).promise();
-          uploadId     = result.UploadId;
-          console.info(`${fileNameInS3} multipart created with upload id: ${uploadId}`);
+          await s3.uploadFile(tempFile, fileNameInS3);
+          deleteTempFile();
+          console.log('successfully uploaded to s3');
         } catch (e) {
-          removeTmpDbFile();
-          throw new Error(`Error creating S3 multipart. ${e.message}`);
-        }
-        
-        const chunkSize  = 10 * 1024 * 1024; // 10MB
-        const readStream = fs.createReadStream(tmpDbFile); // you can use a second parameter here with this option to read with a bigger chunk size than 64 KB: { highWaterMark: chunkSize }
-        
-        // read the file to upload using streams and upload part by part to S3
-        const uploadPartsPromise = new Promise((resolve, reject) => {
-          const multipartMap = {Parts: []};
-          
-          let partNumber       = 1;
-          let chunkAccumulator = null;
-          
-          readStream.on('error', (err) => {
-            reject(err);
-          });
-          
-          readStream.on('data', (chunk) => {
-            // it reads in chunks of 64KB. We accumulate them up to 10MB and then we send to S3
-            if (chunkAccumulator === null) {
-              chunkAccumulator = chunk;
-            } else {
-              chunkAccumulator = Buffer.concat([chunkAccumulator, chunk]);
-            }
-            if (chunkAccumulator.length > chunkSize) {
-              // pause the stream to upload this chunk to S3
-              readStream.pause();
-              
-              const chunkMB = chunkAccumulator.length / 1024 / 1024;
-              
-              const params = {
-                Bucket:        bucket,
-                Key:           fileNameInS3,
-                PartNumber:    partNumber,
-                UploadId:      uploadId,
-                Body:          chunkAccumulator,
-                ContentLength: chunkAccumulator.length,
-              };
-              s3Client.uploadPart(params).promise()
-                .then((result) => {
-                  console.info(`Data uploaded. Entity tag: ${result.ETag} Part: ${params.PartNumber} Size: ${chunkMB}`);
-                  multipartMap.Parts.push({ETag: result.ETag, PartNumber: params.PartNumber});
-                  partNumber++;
-                  chunkAccumulator = null;
-                  // resume to read the next chunk
-                  readStream.resume();
-                }).catch((err) => {
-                  removeTmpDbFile();
-                  console.error(`error uploading the chunk to S3 ${err.message}`);
-                  reject(err);
-              });
-            }
-          });
-          
-          /*readStream.on('end', () => {
-            console.info('End of the stream');
-          });*/
-          
-          readStream.on('close', () => {
-            if (chunkAccumulator) {
-              const chunkMB = chunkAccumulator.length / 1024 / 1024;
-              
-              // upload the last chunk
-              const params = {
-                Bucket:        bucket,
-                Key:           fileNameInS3,
-                PartNumber:    partNumber,
-                UploadId:      uploadId,
-                Body:          chunkAccumulator,
-                ContentLength: chunkAccumulator.length,
-              };
-              
-              s3Client.uploadPart(params).promise()
-                .then((result) => {
-                  console.info(`Last Data uploaded. Entity tag: ${result.ETag} Part: ${params.PartNumber} Size: ${chunkMB}`);
-                  multipartMap.Parts.push({ETag: result.ETag, PartNumber: params.PartNumber});
-                  chunkAccumulator = null;
-                  resolve(multipartMap);
-                }).catch((err) => {
-                  removeTmpDbFile();
-                  console.error(`error uploading the last chunk to S3 ${err.message}`);
-                  reject(err);
-              });
-            }
-          });
-        });
-        
-        const multipartMap = await uploadPartsPromise;
-        
-        console.info(`All parts uploaded, completing multipart upload, parts: ${multipartMap.Parts.length} `);
-        
-        // gather all parts' tags and complete the upload
-        try {
-          const params = {
-            Bucket:          bucket,
-            Key:             fileNameInS3,
-            MultipartUpload: multipartMap,
-            UploadId:        uploadId,
-          };
-          const result = await s3Client.completeMultipartUpload(params).promise();
-          console.info(`Upload multipart completed. Location: ${result.Location} Entity tag: ${result.ETag}`);
-          removeTmpDbFile();
-        } catch (e) {
-          removeTmpDbFile();
-          throw new Error(`Error completing S3 multipart. ${e.message}`);
+          deleteTempFile();
+          throw e;
         }
       }
     });
@@ -181,6 +69,6 @@ module.exports = {
 	cronTime: '0 0 1 * * *',
 	runOnInit: true,
 	onTick: async function() {
-    backupMongoDBToS3();
+    return backupMongoDBToS3();
 	}
 };

--- a/src/cron/mysql_backups.js
+++ b/src/cron/mysql_backups.js
@@ -10,6 +10,11 @@ module.exports = {
 	cronTime: '0 0 1 * * *',
 	runOnInit: true,
 	onTick: function() {
+    // Do not run this cronjob if we have PREVENT_BACKUP_CRONJOBS set to true, or if the S3_DBS_TO_BACKUP is not empty (which means we want to backup to S3).
+    if (!!process.env.PREVENT_BACKUP_CRONJOBS === true || !!process.env.S3_DBS_TO_BACKUP === false) {
+      return;
+    }
+    
     const mysqlRootPw = process.env.MYSQL_ROOT_PASS;
     const objectStoreUrl = process.env.OBJECT_STORE_URL;
     const objectStoreUser = process.env.OBJECT_STORE_USER;

--- a/src/services/awsS3.js
+++ b/src/services/awsS3.js
@@ -1,0 +1,137 @@
+const AwsS3 = require('aws-sdk');
+const fs     = require('fs');
+
+const getClient = () => {
+  const spacesEndpoint = new AwsS3.Endpoint(process.env.S3_ENDPOINT);
+  
+  const s3Config = {
+    endpoint:        spacesEndpoint,
+    accessKeyId:     process.env.S3_KEY,
+    secretAccessKey: process.env.S3_SECRET
+  }
+  
+  if (process.env.S3_FORCE_PATH_STYLE) {
+    s3Config.s3ForcePathStyle = process.env.S3_FORCE_PATH_STYLE;
+  }
+  
+  return new AwsS3.S3(s3Config);
+}
+
+const uploadFile = async (localFile, fileNameInS3) => {
+  
+  let uploadId;
+  const s3Client = getClient();
+  
+  try {
+    const params = {
+      Bucket: process.env.S3_BUCKET,
+      Key:    fileNameInS3,
+      ACL:    "private"
+    };
+    const result = await s3Client.createMultipartUpload(params).promise();
+    uploadId     = result.UploadId;
+    console.info(`${fileNameInS3} multipart created with upload id: ${uploadId}`);
+  } catch (e) {
+    throw new Error(`Error creating S3 multipart. ${e.message}`);
+  }
+  
+  const chunkSize  = 10 * 1024 * 1024; // 10MB
+  const readStream = fs.createReadStream(localFile);
+  
+  // read the file to upload using streams and upload part by part to S3
+  const uploadPartsPromise = new Promise((resolve, reject) => {
+    const multipartMap = {Parts: []};
+    
+    let partNumber       = 1;
+    let chunkAccumulator = null;
+    
+    readStream.on('error', (err) => {
+      reject(err);
+    });
+    
+    readStream.on('data', (chunk) => {
+      // it reads in chunks of 64KB. We accumulate them up to 10MB and then we send to S3
+      if (chunkAccumulator === null) {
+        chunkAccumulator = chunk;
+      } else {
+        chunkAccumulator = Buffer.concat([chunkAccumulator, chunk]);
+      }
+      if (chunkAccumulator.length > chunkSize) {
+        // pause the stream to upload this chunk to S3
+        readStream.pause();
+        
+        const chunkMB = chunkAccumulator.length / 1024 / 1024;
+        
+        const params = {
+          Bucket:        process.env.S3_BUCKET,
+          Key:           fileNameInS3,
+          PartNumber:    partNumber,
+          UploadId:      uploadId,
+          Body:          chunkAccumulator,
+          ContentLength: chunkAccumulator.length,
+        };
+        s3Client.uploadPart(params).promise()
+          .then((result) => {
+            console.info(`Data uploaded. Entity tag: ${result.ETag} Part: ${params.PartNumber} Size: ${chunkMB}`);
+            multipartMap.Parts.push({ETag: result.ETag, PartNumber: params.PartNumber});
+            partNumber++;
+            chunkAccumulator = null;
+            // resume to read the next chunk
+            readStream.resume();
+          }).catch((err) => {
+          console.error(`error uploading the chunk to S3 ${err.message}`);
+          reject(err);
+        });
+      }
+    });
+    
+    readStream.on('close', () => {
+      if (chunkAccumulator) {
+        const chunkMB = chunkAccumulator.length / 1024 / 1024;
+        
+        // upload the last chunk
+        const params = {
+          Bucket:        process.env.S3_BUCKET,
+          Key:           fileNameInS3,
+          PartNumber:    partNumber,
+          UploadId:      uploadId,
+          Body:          chunkAccumulator,
+          ContentLength: chunkAccumulator.length,
+        };
+        
+        s3Client.uploadPart(params).promise()
+          .then((result) => {
+            console.info(`Last Data uploaded. Entity tag: ${result.ETag} Part: ${params.PartNumber} Size: ${chunkMB}`);
+            multipartMap.Parts.push({ETag: result.ETag, PartNumber: params.PartNumber});
+            chunkAccumulator = null;
+            resolve(multipartMap);
+          }).catch((err) => {
+          console.error(`error uploading the last chunk to S3 ${err.message}`);
+          reject(err);
+        });
+      }
+    });
+  });
+  
+  const multipartMap = await uploadPartsPromise;
+  
+  console.info(`All parts uploaded, completing multipart upload, parts: ${multipartMap.Parts.length} `);
+  
+  // gather all parts' tags and complete the upload
+  try {
+    const params = {
+      Bucket:          process.env.S3_BUCKET,
+      Key:             fileNameInS3,
+      MultipartUpload: multipartMap,
+      UploadId:        uploadId,
+    };
+    const result = await s3Client.completeMultipartUpload(params).promise();
+    console.info(`Upload multipart completed. Location: ${result.Location} Entity tag: ${result.ETag}`);
+    return result;
+  } catch (e) {
+    throw new Error(`Error completing S3 multipart. ${e.message}`);
+  }
+}
+
+
+module.exports = {getClient, uploadFile};


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description

This PR adds a new entry point (backup.js) to run backups from. This allows us to create a kubernetes cronjob (see https://github.com/openstad/openstad-kubernetes/pull/101) to perform the backups outside of the API pod.

## Type of change

New feature

## Tests

Tested locally

